### PR TITLE
v1.0.2

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,23 +1,23 @@
 ---
-description: 웹스토어 배포 (main 가드 → 버전 범프 → 태그 push → 스토어 빌드 → zip → 심사 요청 안내)
+description: 웹스토어 배포 (main 가드 → tag push → 스토어 빌드 → zip → 심사 요청 안내)
 ---
 
-Chrome 웹스토어 배포 흐름. main 브랜치에서만 실행. 버전 범프 + 태그 + 스토어 빌드 산출물 패키징 + 크롬 웹스토어 심사 요청 가이드까지 한 번에 진행한다.
+Chrome 웹스토어 배포 흐름. main 브랜치에서만 실행. 버전 bump는 이미 `/merge` 단계에서 PR에 포함돼 main에 들어와 있다고 가정하고, `/deploy`는 그 버전을 가리키는 tag를 origin에 push + 스토어 빌드 산출물 패키징 + 크롬 웹스토어 심사 요청 가이드까지 한 번에 진행한다.
 
 ## 워크플로우 위치
 
 ```
 1. dev 기준 pull → 작업 (/pull → 코드 작성 → /build로 검증)
 2. dev push (/push)
-3. /merge — dev → main squash PR
-4. main 체크아웃 + git pull → /deploy ← 여기
+3. /merge — dev 위에서 버전 bump 커밋 + dev → main squash PR
+4. main 체크아웃 + git pull → /deploy ← 여기 (tag만 push)
 5. dev 동기화 (force push, /deploy 마지막 안내 따라 수동 실행)
 ```
 
 ## 사전 가정
 
-- main 브랜치 프로텍션이 걸려 있되 `enforce_admins: false`라 admin(본인)은 보호 우회 push 가능. 우회가 막혀있으면 `/deploy`는 push 단계에서 멈추고 안내한다.
-- `pnpm version`이 만드는 commit + tag는 main에 직접 쌓이고 dev에는 없으므로, 배포 후 dev 동기화가 필요하다.
+- main 브랜치 프로텍션은 그대로 유효해도 무방. **tag push는 branch ref가 아니라서 보호 규칙을 우회 없이 통과**한다 (tag protection rule이 별도로 걸려 있지 않은 한).
+- `package.json`의 버전은 `/merge`에서 bump된 후 main에 squash 머지된 상태여야 한다. 그렇지 않으면 이번 배포는 직전 배포와 같은 버전이 되고, Chrome 웹스토어가 거부한다.
 
 ## 절차
 
@@ -27,25 +27,25 @@ Chrome 웹스토어 배포 흐름. main 브랜치에서만 실행. 버전 범프
 1. **사전 점검 (병렬 실행)**
    - `git status` — 미커밋 변경 확인. 있으면 "먼저 커밋하세요" 안내 후 중단.
    - `git fetch origin main && git status -uno` — main이 origin/main과 동기 상태인지. 뒤처지면 `git pull` 안내 후 중단.
-   - `node -p "require('./package.json').version"` — 현재 버전 확인
-   - `git log --oneline -10` — 직전 머지/배포 이후 변경 흐름
+   - `node -p "require('./package.json').version"` — 배포할 버전 확인
+   - `git tag -l "v$(node -p \"require('./package.json').version\")"` — 같은 tag가 이미 존재하는지
+   - `git log --oneline -10` — 직전 머지 흐름
 
-2. **버전 범프.** 사용자에게 범프 레벨을 물어본다:
-   - `patch` — 버그 수정 (기본)
-   - `minor` — 기능 추가
-   - `major` — Breaking change
-   - `skip` — 이미 범프했으면 건너뜀
+2. **버전/태그 검증.**
+   - `package.json` 버전이 직전 배포 버전과 같으면 (= `/merge`에서 bump를 깜빡한 경우) 즉시 중단:
+     > 현재 버전이 직전 배포와 동일합니다. `/merge`에서 버전 bump를 빠뜨렸거나 같은 버전을 재배포하려는 상황입니다. 의도된 거면 dev에서 bump 후 다시 `/merge` → `/deploy` 하세요.
+   - 같은 이름의 tag가 이미 있으면 (로컬이든 origin이든) 중단하고 알린다. 사용자가 의도적으로 재배포하는 거면 tag 삭제 후 재시도하라고 안내.
 
-   선택 후 `pnpm version <level>` 실행. (package.json 수정 + commit + tag를 한 번에 처리. main 브랜치에 새 commit과 tag 생성.)
-
-3. **버전 커밋 + 태그 push.** `git push --follow-tags`로 main의 새 commit과 tag를 origin에 반영.
-   - 정상: `main -> main` + `[new tag] vX.Y.Z` 출력 확인.
-   - 거부 시 (`protected branch hook declined`): 즉시 중단하고 안내:
-     > main 보호 우회가 막혀 있어 push가 거부됐습니다. Settings > Branches에서 `Allow specified actors to bypass`에 본인을 추가하거나, 임시로 보호를 풀고 push 후 재적용하세요.
-   - **거부 시 zip/업로드 단계로 넘어가지 않는다** (스토어 산출물의 버전이 SCM에 미반영된 상태로 배포되는 걸 막음).
+3. **tag 생성 + push.**
+   ```
+   git tag v<version>
+   git push origin v<version>
+   ```
+   - branch가 아닌 tag ref만 push하므로 main 브랜치 보호 규칙과 무관하게 통과한다.
+   - 거부 시 (예: tag protection rule이 별도로 걸려 있는 경우): 즉시 중단하고 안내한다. zip 단계로 넘어가지 않는다.
 
 4. **스토어 빌드.** `pnpm build:store` 실행 (timeout 300000ms). `BUGSHOT_STORE_BUILD=1`로 manifest의 dev용 `key`가 빠진 산출물을 만든다.
-   - 실패 시 에러 보고 + 중단 (이미 push된 commit/tag는 그대로 두되 사용자에게 알림).
+   - 실패 시 에러 보고 + 중단 (이미 push된 tag는 그대로 두되 사용자에게 알림 — 같은 버전 재시도하려면 tag 삭제 후 재실행).
    - 성공 시 주요 번들 크기만 간결히 보고 (폰트 subset 로그 생략).
 
 5. **zip 패키징.**
@@ -65,13 +65,14 @@ Chrome 웹스토어 배포 흐름. main 브랜치에서만 실행. 버전 범프
    - 심사 통과 시 자동 publish (며칠 ~ 1주 단위 소요)
 
    ### dev 동기화
-   main에 새 버전 commit + tag가 생겼으므로 dev를 main으로 fast-forward 시켜야 다음 PR diff가 깔끔해진다.
-   `/sync` 실행 권장 (force push라 별도 스킬에서 사용자 승인 받음).
+   `/merge` 직후 dev가 squash 머지로 인해 main과 분기돼 있다. 아직 `/sync`를 안 했다면 지금이라도 실행 권장 (force push라 별도 스킬에서 사용자 승인 받음).
 
 ## 주의
 
 - **main이 아닌 브랜치에서는 절대 진행하지 않는다** (절차 0에서 차단).
 - 미커밋 변경이 있으면 절대 진행하지 않는다.
-- 버전 commit + tag가 origin에 push되지 못하면 zip 단계로 넘어가지 않는다.
+- 버전 bump는 이 스킬의 책임이 아니다. `/merge`에서 처리. `/deploy`에서 `pnpm version` 실행 금지.
+- 같은 버전 tag가 이미 origin에 있으면 강제 덮어쓰기(`git push -f origin v<version>`) 금지 — 의도가 명확할 때만 사용자가 직접 처리.
+- tag push가 실패하면 zip 단계로 넘어가지 않는다 (스토어 산출물의 버전이 SCM에 미반영된 상태로 배포되는 걸 막음).
 - 빌드 전 코드 수정 금지.
 - 스토어 업로드는 사용자가 대시보드에서 직접 수행한다 (자동화 금지 — 심사 제출 실수 방지).

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,8 +1,10 @@
 ---
-description: dev → main PR 생성 + squash 머지 + dev 동기화
+description: dev → main PR 생성 + 버전 bump + squash 머지 + dev 동기화
 ---
 
-현재 작업 브랜치(보통 `dev`)를 `main`에 PR squash merge로 합치고, 머지 후 dev를 main과 동기화한다. main은 브랜치 프로텍션이 걸려있어 직접 push가 막혀있고, PR이 셀프 머지 가능한 환경 가정.
+현재 작업 브랜치(보통 `dev`)에 버전 bump 커밋을 얹은 뒤 `main`에 PR squash merge로 합치고, 머지 후 dev를 main과 동기화한다. main은 브랜치 프로텍션이 걸려있어 직접 push가 막혀있고, PR이 셀프 머지 가능한 환경 가정.
+
+버전 bump를 머지 단계에서 처리하는 이유: bump 커밋이 PR에 포함돼서 squash로 main에 자연스럽게 들어가기 때문에 main 직접 push / 보호 우회가 필요 없다. tag는 `/deploy`에서 main HEAD를 가리키도록 별도로 찍는다.
 
 ## 절차
 
@@ -12,6 +14,7 @@ description: dev → main PR 생성 + squash 머지 + dev 동기화
    - `git log @{u}..HEAD --oneline` — 푸시되지 않은 로컬 커밋
    - `git log origin/main..HEAD --oneline` — main 대비 머지될 커밋 목록
    - `gh pr list --base main --head <current-branch> --state open --json number,title,url` — 기존 열린 PR 있는지
+   - `node -p "require('./package.json').version"` — 현재 버전
 
 2. **미커밋 변경이 있으면 멈추고 사용자에게 알린다.** `/merge`는 커밋된 변경만 다룬다. 자동 커밋 금지. 사용자가 `/push`로 먼저 정리하도록 안내.
 
@@ -19,23 +22,39 @@ description: dev → main PR 생성 + squash 머지 + dev 동기화
 
 4. **푸시 안 된 로컬 커밋이 있으면 먼저 푸시.** `git push` (upstream 없으면 `-u origin <branch>`). 푸시 실패하면 원인 보고 후 중단.
 
-5. **PR 준비.**
+5. **버전 bump.** 사용자에게 범프 레벨을 물어본다:
+   - `patch` — 버그 수정 (기본)
+   - `minor` — 기능 추가
+   - `major` — Breaking change
+   - `skip` — 같은 릴리스에 다른 PR이 이미 bump했거나 docs/internal-only 머지면 건너뜀
+
+   `skip`이 아니면:
+   ```
+   pnpm version <level> --no-git-tag-version
+   git add package.json
+   git commit -m "v<new-version>"
+   git push
+   ```
+   `--no-git-tag-version`은 자동 commit/tag 둘 다 막는다. 직접 commit해서 메시지를 통제하고, tag는 절대 만들지 않는다 (squash로 가리켜도 의미 없는 dev HEAD를 가리키게 되므로).
+
+6. **PR 준비.**
    - 기존 PR이 있으면 재사용. 번호와 URL을 보여준다.
-   - 없으면 `gh pr create --base main --head <current-branch> --fill`로 생성. `--fill`은 마지막 커밋 메시지를 title/body로 자동 채움. 머지될 커밋이 여러 개면 fill로 부족할 수 있으니 title을 검토하고, 필요시 `--title`/`--body`로 덮어쓰기 제안.
+   - 없으면 `gh pr create --base main --head <current-branch> --fill`로 생성. `--fill`은 마지막 커밋 메시지를 title/body로 자동 채움. 머지될 커밋이 여러 개거나 마지막 커밋이 버전 bump면 fill로 부족하니 title을 검토하고, 필요시 `--title`/`--body`로 덮어쓰기 제안.
 
-6. **머지 직전 요약 + 사용자 승인.** PR 번호, 제목, 머지될 커밋 목록을 짧게 보여주고 "main에 squash merge해도 되냐" 묻는다. 승인 없으면 중단.
+7. **머지 직전 요약 + 사용자 승인.** PR 번호, 제목, 머지될 커밋 목록(버전 bump 커밋 포함)을 짧게 보여주고 "main에 squash merge해도 되냐" 묻는다. 승인 없으면 중단.
 
-7. **머지 실행.**
+8. **머지 실행.**
    ```
    gh pr merge <number> --squash
    ```
    `--delete-branch`는 기본 OFF (dev 브랜치 살려둠). 머지 결과 출력에서 핵심 줄만 보고.
 
-8. **dev 동기화 안내.** main 머지 후 dev가 main 뒤로 처지지 않게 `/sync` 실행 권장. (force push라 별도 스킬에서 사용자 승인 받음.) 안 하면 다음 PR diff가 지저분해질 수 있음.
+9. **dev 동기화 안내.** main 머지 후 dev가 main 뒤로 처지지 않게 `/sync` 실행 권장. (force push라 별도 스킬에서 사용자 승인 받음.) 안 하면 다음 PR diff가 지저분해질 수 있음. 이어서 배포할 거면 `git checkout main && git pull` 후 `/deploy`로.
 
 ## 금지 사항
 
 - 현재 브랜치가 `main`이면 즉시 중단. main에서 자기 자신으로 머지는 의미 없음.
+- `pnpm version`을 옵션 없이 실행 금지. 반드시 `--no-git-tag-version`으로 tag 생성을 막는다 (tag는 `/deploy`의 책임).
 - `gh pr merge --admin`(브랜치 프로텍션 우회)은 사용자 명시 요청 시에만.
 - `gh pr merge --merge` / `--rebase`로 머지 방식 변경은 사용자 명시 요청 시에만. 기본은 `--squash` (linear history + 1 PR = 1 commit).
 - main 브랜치에 직접 push 시도 금지 (프로텍션이 막지만 시도 자체도 안 함).

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@
 
 VITE_ATLASSIAN_CLIENT_ID=
 VITE_OAUTH_PROXY_URL=
+
+# Chrome Web Store BugShot 페이지 URL (빈 값이면 푸터에 링크 없이 텍스트만 표시)
+VITE_WEBSTORE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,20 +189,20 @@ Jira는 마크다운 원본을 파싱하지 않고, 붙여넣기는 **ProseMirro
 
 ### 버전 체계
 
-semver(`MAJOR.MINOR.PATCH`). `package.json`의 `version`이 manifest에 자동 반영된다. Chrome 웹스토어는 업로드마다 버전이 올라가야 하므로 **`/deploy` 단계에서 반드시 범프**.
+semver(`MAJOR.MINOR.PATCH`). `package.json`의 `version`이 manifest에 자동 반영된다. Chrome 웹스토어는 업로드마다 버전이 올라가야 하므로 **`/merge` 단계에서 dev에 bump 커밋을 얹어 PR에 포함**시키고, squash로 main에 들어간 뒤 `/deploy`가 그 버전을 가리키는 tag만 별도 push한다.
 
 ```bash
-pnpm version patch   # 1.0.0 → 1.0.1 (버그 수정)
-pnpm version minor   # 1.0.0 → 1.1.0 (기능 추가)
-pnpm version major   # 1.0.0 → 2.0.0 (Breaking change)
+pnpm version patch --no-git-tag-version   # 1.0.0 → 1.0.1 (버그 수정)
+pnpm version minor --no-git-tag-version   # 1.0.0 → 1.1.0 (기능 추가)
+pnpm version major --no-git-tag-version   # 1.0.0 → 2.0.0 (Breaking change)
 ```
 
-`pnpm version`은 package.json 수정 + git tag + commit을 한 번에 처리한다.
+`--no-git-tag-version`이 핵심. 자동 commit/tag를 막고 직접 commit 메시지를 통제하며, tag는 **dev HEAD가 아닌 main의 squash 커밋을 가리켜야 의미가 있으므로** `/deploy`에서 찍는다.
 
 ### 브랜치 정책
 
 - 작업 브랜치: **`dev`** — 자유롭게 push (force push 허용).
-- 메인 브랜치: **`main`** — 브랜치 프로텍션 적용. 직접 push 금지, PR squash 머지만 허용(linear history 강제). approval 0이라 1인 셀프 머지 OK. `enforce_admins: false`라 admin(본인)은 deploy의 버전 commit/tag push처럼 긴급 시 우회 가능.
+- 메인 브랜치: **`main`** — 브랜치 프로텍션 적용. 직접 push 금지, PR squash 머지만 허용(linear history 강제). approval 0이라 1인 셀프 머지 OK. 버전 commit은 PR을 통해 들어오고 tag push는 ref 종류가 달라 보호 규칙과 무관하므로, **보호 우회가 필요한 시점이 없다**.
 
 ### 워크플로우 (스킬 라인업)
 
@@ -210,8 +210,8 @@ pnpm version major   # 1.0.0 → 2.0.0 (Breaking change)
 /pull   → dev 최신 받고 작업 맥락 브리핑
 /build  → pnpm build + 테스트 체크리스트 (작업 중 검증)
 /push   → dev push (main에서 호출 차단)
-/merge  → dev → main squash PR 생성 + 자동 머지
-/deploy → main 강제. 버전 범프 → tag push → 스토어 빌드 → zip → 심사 요청 안내
+/merge  → dev에서 버전 bump 커밋 + dev → main squash PR 생성 + 자동 머지
+/deploy → main 한정. tag push → 스토어 빌드 → zip → 심사 요청 안내
 /sync   → dev를 origin/main으로 hard reset + force push (배포/머지 후)
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background/messages.ts
+++ b/src/background/messages.ts
@@ -95,9 +95,10 @@ async function submitIssue(
 
   const uploadMap = new Map<string, UploadedFile>();
   for (const att of attachments) {
+    const filename = att.filename.replaceAll("{key}", issue.key);
     try {
       const blob = dataUrlToBlob(att.dataUrl);
-      const results = await uploadAttachment(auth, issue.key, att.filename, blob);
+      const results = await uploadAttachment(auth, issue.key, filename, blob);
       const r = results[0];
       if (r?.mediaApiFileId) {
         uploadMap.set(att.filename, { kind: "media", mediaId: r.mediaApiFileId });

--- a/src/content/overlay.ts
+++ b/src/content/overlay.ts
@@ -1,3 +1,5 @@
+import { formatElementName } from "@/lib/element-label";
+
 import type { InspectorInfo } from "./css-resolve";
 
 export interface OverlayHandle {
@@ -394,11 +396,10 @@ export function renderOutline(
 
 export function renderBadge(h: OverlayHandle, target: Element): void {
   const o = h as OverlayInternal;
-  const tag = target.tagName.toLowerCase();
-  const cls = Array.from(target.classList).slice(0, 3).map((c) => `.${c}`).join("");
-  const extra = target.classList.length > 3 ? `+${target.classList.length - 3}` : "";
-
-  o.labelEl.textContent = `${tag}${cls}${extra}`;
+  o.labelEl.textContent = formatElementName({
+    tag: target.tagName.toLowerCase(),
+    classList: Array.from(target.classList),
+  });
   o.labelEl.dataset.mode = "badge";
   placeLabel(o, target);
 }

--- a/src/lib/element-label.ts
+++ b/src/lib/element-label.ts
@@ -1,0 +1,29 @@
+export const ELEMENT_LABEL_MAX_CLASSES = 3;
+
+export interface VisibleClasses {
+  shown: string[];
+  extra: number;
+}
+
+export function visibleClasses(classList: string[]): VisibleClasses {
+  return {
+    shown: classList.slice(0, ELEMENT_LABEL_MAX_CLASSES),
+    extra: Math.max(0, classList.length - ELEMENT_LABEL_MAX_CLASSES),
+  };
+}
+
+export interface FormatElementNameOptions {
+  tag: string;
+  classList: string[];
+  id?: string | null;
+  brackets?: boolean;
+}
+
+export function formatElementName(opts: FormatElementNameOptions): string {
+  const { shown, extra } = visibleClasses(opts.classList);
+  const idPart = opts.id ? `#${opts.id}` : "";
+  const clsPart = shown.map((c) => `.${c}`).join("");
+  const extraPart = extra > 0 ? `+${extra}` : "";
+  const inner = `${opts.tag}${idPart}${clsPart}${extraPart}`;
+  return opts.brackets ? `<${inner}>` : inner;
+}

--- a/src/sidepanel/lib/buildAiMetaAttachment.ts
+++ b/src/sidepanel/lib/buildAiMetaAttachment.ts
@@ -1,0 +1,16 @@
+import { buildIssueMarkdown, type MarkdownContext } from "./buildIssueMarkdown";
+
+export const AI_META_FILENAME = "{key}-bugshot.md";
+
+export function buildAiMetaAttachment(
+  ctx: MarkdownContext,
+): { filename: string; dataUrl: string } {
+  const md = buildIssueMarkdown(ctx);
+  const utf8 = new TextEncoder().encode(md);
+  let binary = "";
+  for (const byte of utf8) binary += String.fromCharCode(byte);
+  return {
+    filename: AI_META_FILENAME,
+    dataUrl: `data:text/markdown;base64,${btoa(binary)}`,
+  };
+}

--- a/src/sidepanel/lib/buildIssueAdf.ts
+++ b/src/sidepanel/lib/buildIssueAdf.ts
@@ -1,5 +1,6 @@
 import { t } from "@/i18n";
 import { IMAGE_PLACEHOLDER } from "@/lib/adf-sentinels";
+import { formatElementName } from "@/lib/element-label";
 import type { MarkdownContext } from "./buildIssueMarkdown";
 import { formatTimestamp } from "./formatTimestamp";
 
@@ -38,10 +39,13 @@ export function buildIssueAdf(ctx: MarkdownContext): AdfDoc {
     ];
     content.push(bulletList(items));
   } else {
+    const domLabel = ctx.tagName
+      ? formatElementName({ tag: ctx.tagName, classList: ctx.classListBefore })
+      : "";
     content.push(
       bulletList([
         keyValueItem("Page", ctx.url),
-        keyValueItem("DOM", ctx.selector),
+        ...(domLabel ? [keyValueItem("DOM", domLabel)] : []),
         keyValueItem("Viewport", `${ctx.viewport.width}×${ctx.viewport.height}`),
         keyValueItem("Captured", formatTimestamp(ctx.capturedAt)),
       ]),
@@ -70,7 +74,24 @@ export function buildIssueAdf(ctx: MarkdownContext): AdfDoc {
   content.push(heading(2, t("md.section.expectedResult")));
   content.push(...textBlock(ctx.expectedResult));
 
+  content.push(footerParagraph());
+
   return { version: 1, type: "doc", content };
+}
+
+function footerParagraph(): AdfNode {
+  const url = (import.meta.env.VITE_WEBSTORE_URL as string | undefined) ?? "";
+  const brandMarks: { type: string; attrs?: Record<string, unknown> }[] = [
+    { type: "em" },
+  ];
+  if (url) brandMarks.push({ type: "link", attrs: { href: url } });
+  return {
+    type: "paragraph",
+    content: [
+      { type: "text", text: "Reported via ", marks: [{ type: "em" }] },
+      { type: "text", text: "BugShot", marks: brandMarks },
+    ],
+  };
 }
 
 function heading(level: number, text: string): AdfNode {

--- a/src/sidepanel/lib/buildIssueMarkdown.ts
+++ b/src/sidepanel/lib/buildIssueMarkdown.ts
@@ -72,6 +72,9 @@ export function buildIssueMarkdown(ctx: MarkdownContext): string {
   lines.push(ctx.expectedResult);
   lines.push("");
 
+  lines.push(footerMarkdown());
+  lines.push("");
+
   return lines.join("\n");
 }
 
@@ -122,7 +125,27 @@ export function buildIssueHtml(ctx: MarkdownContext): string {
   parts.push(`<h2>${t("md.section.expectedResult")}</h2>`);
   parts.push(paragraphize(ctx.expectedResult));
 
+  parts.push(footerHtml());
+
   return parts.join("\n");
+}
+
+function webstoreUrl(): string {
+  return (import.meta.env.VITE_WEBSTORE_URL as string | undefined) ?? "";
+}
+
+function footerMarkdown(): string {
+  const url = webstoreUrl();
+  const brand = url ? `[BugShot](${url})` : "BugShot";
+  return `_Reported via ${brand}_`;
+}
+
+function footerHtml(): string {
+  const url = webstoreUrl();
+  const brand = url
+    ? `<a href="${escapeHtml(url)}">BugShot</a>`
+    : "BugShot";
+  return `<p><em>Reported via ${brand}</em></p>`;
 }
 
 function buildMetaComment(ctx: MarkdownContext): string {

--- a/src/sidepanel/tabs/DomTreeDialog.tsx
+++ b/src/sidepanel/tabs/DomTreeDialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { formatElementName, visibleClasses } from "@/lib/element-label";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/store/editor-store";
 import type { TreeNode } from "@/types/picker";
@@ -55,16 +56,10 @@ export function DomNavButton({ direction }: { direction: "parent" | "child" }) {
   );
 }
 
-export function formatElementName(tagName: string, classList: string[]): string {
-  const cls = classList.slice(0, 3).map((c) => `.${c}`).join("");
-  const extra = classList.length > 3 ? `+${classList.length - 3}` : "";
-  return `${tagName}${cls}${extra}`;
-}
-
 export function DomTreeTitle({ tagName, classList }: { tagName: string; classList: string[] }) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  const label = formatElementName(tagName, classList);
+  const label = formatElementName({ tag: tagName, classList });
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -266,16 +261,21 @@ function DomTreeNode({
           {node.id ? (
             <span className="text-fuchsia-600">#{node.id}</span>
           ) : null}
-          {node.classes.slice(0, 3).map((c) => (
-            <span key={c} className="text-amber-600">
-              .{c}
-            </span>
-          ))}
-          {node.classes.length > 3 ? (
-            <span className="text-muted-foreground">
-              +{node.classes.length - 3}
-            </span>
-          ) : null}
+          {(() => {
+            const { shown, extra } = visibleClasses(node.classes);
+            return (
+              <>
+                {shown.map((c) => (
+                  <span key={c} className="text-amber-600">
+                    .{c}
+                  </span>
+                ))}
+                {extra > 0 ? (
+                  <span className="text-muted-foreground">+{extra}</span>
+                ) : null}
+              </>
+            );
+          })()}
           <span className="text-muted-foreground">&gt;</span>
           {node.childCount > 0 && !isOpen ? (
             <span className="ml-1 text-muted-foreground">

--- a/src/sidepanel/tabs/DraftDetailDialog.tsx
+++ b/src/sidepanel/tabs/DraftDetailDialog.tsx
@@ -28,6 +28,7 @@ import { Label } from "@/components/ui/label";
 import { formatElementName } from "@/lib/element-label";
 import { useEditorStore } from "@/store/editor-store";
 import { useIssuesStore, type IssueRecord } from "@/store/issues-store";
+import { clearPicker } from "../picker-control";
 import {
   useSettingsStore,
   isJiraConfigComplete,
@@ -193,6 +194,8 @@ export function DraftDetailDialog({
       assigneeName: fields.assigneeName,
     });
     if (useEditorStore.getState().currentIssueId === issue.id) {
+      const tabId = useEditorStore.getState().target?.tabId;
+      if (tabId != null) void clearPicker(tabId);
       useEditorStore.getState().reset();
     }
     useSettingsStore.getState().setLastSubmitFields({

--- a/src/sidepanel/tabs/DraftDetailDialog.tsx
+++ b/src/sidepanel/tabs/DraftDetailDialog.tsx
@@ -25,6 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { formatElementName } from "@/lib/element-label";
 import { useEditorStore } from "@/store/editor-store";
 import { useIssuesStore, type IssueRecord } from "@/store/issues-store";
 import {
@@ -37,6 +38,7 @@ import {
   StyleChangesTable,
   buildStyleDiff,
 } from "../components/StyleChangesTable";
+import { buildAiMetaAttachment } from "../lib/buildAiMetaAttachment";
 import { buildIssueAdf } from "../lib/buildIssueAdf";
 import { SubmitFieldsDialog } from "./IssueCreateModal";
 
@@ -143,7 +145,9 @@ export function DraftDetailDialog({
 
     const summary = issue.draft.title.trim();
 
-    const attachments: { filename: string; dataUrl: string }[] = [];
+    const attachments: { filename: string; dataUrl: string }[] = [
+      buildAiMetaAttachment(ctx),
+    ];
     if (isVideo) {
       const blob = await getVideoBlob(issue.id);
       if (blob) {
@@ -355,8 +359,16 @@ function FieldSection({
 function EnvBlock({ issue }: { issue: IssueRecord }) {
   const rows: { label: string; value: string }[] = [
     { label: "Page", value: issue.pageUrl || "-" },
-    ...(issue.captureMode !== "video" && issue.selector
-      ? [{ label: "DOM", value: issue.selector }]
+    ...(issue.captureMode !== "video" && issue.tagName
+      ? [
+          {
+            label: "DOM",
+            value: formatElementName({
+              tag: issue.tagName,
+              classList: issue.selectionSnapshot?.classList ?? [],
+            }),
+          },
+        ]
       : []),
   ];
   const vp = issue.viewport ?? issue.selectionSnapshot?.viewport;

--- a/src/sidepanel/tabs/IssueCreateModal.tsx
+++ b/src/sidepanel/tabs/IssueCreateModal.tsx
@@ -45,6 +45,7 @@ import type {
 } from "@/types/jira";
 import { sendBg, type JiraSubmitResult } from "@/types/messages";
 import { buildStyleDiff } from "../components/StyleChangesTable";
+import { buildAiMetaAttachment } from "../lib/buildAiMetaAttachment";
 import { buildIssueAdf, type AdfDoc } from "../lib/buildIssueAdf";
 
 type SubmitState =
@@ -105,6 +106,7 @@ export function IssueCreateModal() {
         diffs: [],
       };
       description = buildIssueAdf(ctx);
+      attachments.push(buildAiMetaAttachment(ctx));
       if (videoBlob) {
         const dataUrl = await blobToDataUrl(videoBlob);
         attachments.push({ filename: "recording.webm", dataUrl });
@@ -128,6 +130,7 @@ export function IssueCreateModal() {
         diffs: [],
       };
       description = buildIssueAdf(ctx);
+      attachments.push(buildAiMetaAttachment(ctx));
       if (screenshotImage) attachments.push({ filename: "screenshot.jpg", dataUrl: screenshotImage });
     } else {
       if (!selection) throw new Error("필수 값 누락");
@@ -148,6 +151,7 @@ export function IssueCreateModal() {
         diffs,
       };
       description = buildIssueAdf(ctx);
+      attachments.push(buildAiMetaAttachment(ctx));
       if (beforeImage) attachments.push({ filename: "before.jpg", dataUrl: beforeImage });
       if (afterImage) attachments.push({ filename: "after.jpg", dataUrl: afterImage });
     }

--- a/src/sidepanel/tabs/IssueTypeCombobox.tsx
+++ b/src/sidepanel/tabs/IssueTypeCombobox.tsx
@@ -95,7 +95,10 @@ export function IssueTypeCombobox() {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        onWheel={(e) => e.stopPropagation()}
+      >
         <Command>
           <CommandInput placeholder={t("field.issueType.search")} />
           <CommandList>

--- a/src/sidepanel/tabs/ProjectCombobox.tsx
+++ b/src/sidepanel/tabs/ProjectCombobox.tsx
@@ -85,7 +85,10 @@ export function ProjectCombobox() {
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        onWheel={(e) => e.stopPropagation()}
+      >
         <Command>
           <CommandInput placeholder={t("project.search")} />
           <CommandList>

--- a/src/store/issues-store.ts
+++ b/src/store/issues-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { chromeLocalStorage } from "./chrome-storage";
 import { useEditorStore, type CaptureMode } from "./editor-store";
+import { clearPicker } from "@/sidepanel/picker-control";
 import {
   deleteVideoBlob,
   clearVideoBlobs,
@@ -58,6 +59,8 @@ async function pruneOrphanBlobs(): Promise<void> {
 function resetEditorIfEditing(removedId: string | null): void {
   const state = useEditorStore.getState();
   if (removedId === null || state.currentIssueId === removedId) {
+    const tabId = state.target?.tabId;
+    if (tabId != null) void clearPicker(tabId);
     state.reset();
   }
 }


### PR DESCRIPTION
## 변경 사항

### Fixes
- **fix(settings)**: 프로젝트/이슈 타입 Combobox popover 안에서 마우스 휠로 리스트 스크롤이 안 되던 문제. PopoverContent에 `onWheel` stopPropagation 추가해 부모 PageScroll이 이벤트를 가로채는 걸 차단.
- **fix(picker)**: 이슈 목록에서 현재 편집 중인 초안 제출/삭제 시 페이지 overlay가 잔류하던 문제. editor reset 직전 `clearPicker(tabId)` 호출.

### Features
- **feat(issue)**: DOM 표시 일관화 + AI 메타 첨부 + 본문 푸터.

### Workflow
- **docs**: 버전 bump를 \`/merge\`로 이전, \`/deploy\`는 tag-only로 단순화. 이번 PR이 새 흐름의 첫 적용 케이스.

### Release
- v1.0.1 → **v1.0.2**

## 테스트
- [x] pnpm build 성공
- [ ] 머지 후 \`/deploy\`로 tag push + 스토어 빌드 + 심사 요청