### PR TITLE
v1.1.5 — GitHub inline upload regression fix, mp4 recording, issue list UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,7 @@ CSSOM이 보여주는 것: `border-top-left-radius: ""` / `border-top-right-radi
 
 content_scripts에 MAIN world entry(`run_at: "document_start"`)로 `src/content/recorders-entry.ts`를 등록해 모든 페이지의 fetch/XHR/sendBeacon/console.*을 자동 wrap. 페이지 자체 스크립트보다 먼저 실행되므로 Sentry 등 SDK가 `originalFetch`를 캐싱하기 전에 wrap이 끼어든다.
 
-**document_start부터 무조건 buffer (옵션 A)** — wrap 설치 즉시 buffer에 적재한다. sentinel은 dispatch 채널 식별용일 뿐이며, sentinel 도착 전에 발생한 첫 fetch도 누락되지 않는다. 메모리는 50MB cap + LRU trim으로 보호. 사이드패널이 켜져 있지 않아도 buffer가 차오를 수 있는 비용이 있지만, recording 시작 시점에 이미 시나리오 재현이 진행 중인 케이스를 커버하기 위해 채택.
+**document_start부터 무조건 buffer (옵션 A)** — wrap 설치 즉시 buffer에 적재한다. sentinel은 dispatch 채널 식별용일 뿐이며, sentinel 도착 전에 발생한 첫 fetch도 누락되지 않는다. 메모리는 두 단계로 보호: (1) 50MB body cap + LRU trim(`enforceMemoryCap`)이 본문을 omitted로 회수, (2) 5000 entry FIFO cap(`enforceEntryCap`)이 본문 없는 요청(HEAD/204/binary beacon) 폭증으로부터 buffer 길이 자체를 막는다. cap 도달 시 oldest를 버리는 FIFO — 버그 재현 시나리오에서 가치 있는 신호는 후반부라는 가정. 사이드패널이 켜져 있지 않아도 buffer가 차오를 수 있는 비용이 있지만, recording 시작 시점에 이미 시나리오 재현이 진행 중인 케이스를 커버하기 위해 채택. console-recorder도 동일하게 2000 entry FIFO + `clearBuffer`가 counters/timers Map까지 리셋.
 
 **요청 phase 추적** — fetch/XHR send 시점에 `phase: "pending"` entry를 push하고, 응답 완료 시 `phase: "complete"`, reject/abort/error/timeout 시 `phase: "error"`로 in-place 갱신. 따라서 sync 시점에 in-flight 요청도 가시화되고, navigation으로 끊긴 요청은 pending으로 남아 디버깅 단서가 된다. summary는 `phase=error`를 status=0이어도 에러로 집계하므로 CORS·네트워크 실패가 이슈 본문에서 누락되지 않는다.
 
@@ -189,6 +189,8 @@ content_scripts에 MAIN world entry(`run_at: "document_start"`)로 `src/content/
 UI(`NetworkLogPreviewDialog`)와 HAR export 모두 이 context를 살려 "본문 잘림 (5.0 MB · 한도 3.0 MB)" / "Binary response (image/png · 500 B)" 등 정확한 사유를 표시.
 
 **클리어 트리거** — `useBackgroundRecorder`의 store 구독이 `preserve phase → idle` 전환을 감지하면 pending IndexedDB + MAIN buffer를 정리한 뒤 새 sentinel 발급. `shouldPreserveBackgroundLogs(phase)` = `recording / drafting / previewing / done`. 작성 취소, 정상 제출 후 reset, 녹화 중 취소 모두 이 분기에서 일괄 처리.
+
+**고아 pending 정리 (SW 부트)** — `pending:${tabId}` IndexedDB 엔트리는 평소 `chrome.tabs.onRemoved`·URL 변경·이슈 저장 3경로로 정리되지만, 브라우저 강제 종료·확장 reload·SW 휴면 중 탭 종료 등으로 onRemoved가 누락되면 영구 잔류한다. `src/lib/pending-log-prune.ts`의 `pruneOrphanPendingLogsOncePerSession()`이 SW 부트 시 `chrome.storage.session.pendingPrunedAt` 플래그로 세션당 1회만 도는 가드를 두고, 현재 `chrome.tabs.query({})` 결과에 없는 tabId의 `pending:` 엔트리를 회수. `findOrphanPendingKeys`는 순수 함수로 분리해 테스트.
 
 **race 회피** — clear → setSentinel을 sequential `await`로 강제. fire-and-forget이면 Chrome 메시지 큐 처리 순서 미보장으로 setSentinel이 먼저 처리되어 이전 sentinel의 clearHandler가 detach → 후속 clear가 무시되는 경로가 가능. sequential로 picker.ts 처리 round-trip을 기다린 뒤 setSentinel.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,6 +204,16 @@ UI(`NetworkLogPreviewDialog`)와 HAR export 모두 이 context를 살려 "본문
 
 **Cross-tab 메시지 격리** — `chrome.runtime.sendMessage`는 모든 extension contexts에 broadcast되므로 다른 탭의 content script가 보낸 `networkRecorder.data`/`consoleRecorder.data`/`picker.*`도 내 사이드패널 핸들러에 도달한다. `usePickerMessages`가 핸들러 진입부에서 `sender.tab?.id !== myTabId`인 메시지를 drop — 그러지 않으면 같은 origin/다른 path의 두 탭에서 동시에 녹화 중일 때 한 사이드패널이 다른 탭의 로그로 자기 store/IDB를 덮어쓰는 버그가 발생한다. `sender.tab` 부재(사이드패널/서비스워커 내부 통신)는 통과.
 
+## chrome.scripting.executeScript MAIN world 주입 규칙
+
+`chrome.scripting.executeScript({ world: "MAIN", func })`의 `func` 인자는 `Function.prototype.toString()`으로 직렬화 후 대상 탭의 페이지 컨텍스트에서 **재평가**된다. SW의 모듈 스코프 클로저는 살아남지 않는다 — 모듈 스코프의 헬퍼 함수·상수를 참조하면 페이지에서 `ReferenceError`로 즉시 throw, 반환 Promise가 reject되어 `result.result === null`로 떨어진다.
+
+규칙: 주입 함수는 **self-contained**여야 한다. 헬퍼는 nested function으로 inline하거나 함수 인자로 전달. 글로벌(`fetch`/`FormData`/`Blob`/`URL`/`atob` 등)과 인자만 사용 가능.
+
+현재 사용처: `src/background/github-upload.ts:pageBatchUploadFn` (issue attachment 업로드). `network/console-recorder`는 content_scripts MAIN world entry라서 모듈 번들 통째로 실행되므로 별개 — 이 규칙은 **런타임 SW→탭 주입**에만 해당.
+
+방어선: TypeScript는 같은 모듈 참조라 잡지 못하고, 단위 테스트도 MAIN world 직렬화 경계를 재현하기 어렵다. **GitHub 인라인 업로드 같은 inject 경로는 수동 회귀가 유일한 방어선**. v1.1.2에서 단일 파일 업로드 → `Promise.all` 병렬화 리팩터로 `uploadOne`을 모듈 스코프로 추출하면서 이 규칙을 위반, v1.1.4까지 latent로 남아 있었다. inject 함수 본체를 리팩터·헬퍼 추출할 땐 항상 실제 탭에서 한 번 더 확인.
+
 ## DOM 트리 Lazy Load
 
 DOM 트리 Dialog(`IssueTab.tsx`의 `DomTree`)는 큰 페이지에서 전체 DOM을 한 번에 직렬화하면 프리즈된다. 그래서 두 단계로 동작:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,9 @@ src/
 │   ├── overlay.ts         # Shadow DOM 오버레이 (아웃라인·배너·블로커·프리뷰)
 │   ├── area-select.ts     # 영역 드래그 선택 (dimming + 사이즈 라벨)
 │   ├── recorders-entry.ts # MAIN world content_scripts entry (document_start) — network/console 레코더 자기 호출
-│   ├── network-recorder.ts# MAIN world 네트워크 캡처 (fetch/XHR/sendBeacon 래핑, send 시점 phase="pending" entry push → 완료/에러 시 in-place 갱신, body omission에 size/limit/contentType context, 50MB cap)
+│   ├── network-recorder.ts# MAIN world 네트워크 캡처 (fetch/XHR/sendBeacon 래핑, send 시점 phase="pending" entry push → 완료/에러 시 in-place 갱신, body omission에 size/limit/contentType context, 50MB body cap + 5000 entry FIFO)
 │   ├── network-recorder-helpers.ts# classifyResponseBody / classifyBeaconBody 순수 헬퍼 + BODY_CAP (3MB)
-│   ├── console-recorder.ts# MAIN world 콘솔 캡처 (log/info/debug + trace/assert/dir/table/group*/count*/time* wrap, error/warn은 chrome://extensions attribution noise 회피로 의도적 제외 — throw 에러는 window.error/unhandledrejection으로 별도 캡처, 2000건 캡, document_start부터 무조건 buffer)
+│   ├── console-recorder.ts# MAIN world 콘솔 캡처 (log/info/debug + trace/assert/dir/table/group*/count*/time* wrap, error/warn은 chrome://extensions attribution noise 회피로 의도적 제외 — throw 에러는 window.error/unhandledrejection으로 별도 캡처, 2000건 FIFO, document_start부터 무조건 buffer, clearBuffer는 counters/timers Map도 함께 리셋)
 │   ├── console-recorder-helpers.ts# formatErrorEvent / formatRejectionReason / shouldCaptureAssertion 순수 헬퍼
 │   └── __tests__/         # network-recorder-helpers.test.ts / console-recorder-helpers.test.ts
 ├── sidepanel/
@@ -86,7 +86,7 @@ src/
 │                        # settings-ui v5: LlmConfig { baseUrl, apiKey, modelId } 전부 chrome.storage.local 영속
 │                        # issues v5: entry에 platform: PlatformId 필드 + notion 한정 메타 (notionPageId/notionDatabaseId 등)
 ├── i18n/                # 다국어 (ko/en 로케일, t()/useT() 훅)
-├── lib/                 # 공용 유틸 (session-keys, adf-sentinels, url-support, settings-storage, notion-page-id, key-obfuscation)
+├── lib/                 # 공용 유틸 (session-keys, adf-sentinels, url-support, settings-storage, notion-page-id, key-obfuscation, pending-log-prune)
 ├── components/ui/       # shadcn 컴포넌트
 ├── styles/
 └── types/               # platform.ts (PlatformId/Accounts/LastSubmitFieldsByPlatform), github.ts, jira.ts, linear.ts, notion.ts 등

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ src/
 │   │   ├── linearFields/  # Linear 메타 필드 컴포넌트 (TeamCombobox, ProjectCombobox, LabelCombobox, PrioritySelect, AssigneeCombobox, LinearIssueFields 묶음) — IntegrationsTab/IssueCreateModal 양쪽에서 controlled로 재사용
 │   │   ├── notionFields/  # Notion 메타 필드 컴포넌트 (DatabaseCombobox, StatusSelect, PropertiesFieldset, PropertySelectCombobox, NotionIssueFields 묶음, reconcileNotionFields 헬퍼) — IntegrationsTab/IssueCreateModal 양쪽에서 controlled로 재사용
 │   │   └── notionStatusColors.ts  # Notion status option color → STATUS_CATEGORY (new/indeterminate/done) 매핑
-│   └── lib/             # buildIssueMarkdown, buildIssueAdf, buildGithubIssueBody, buildLinearIssueBody, buildNotionIssueBody, submitToGithub, submitToLinear, submitToNotion(NormalizedSubmitResult), buildAiDraftPrompt, buildAiStylingPrompt, aiStylingPostProcess, ai-provider(BYOK 프로바이더 팩토리·프리셋·멀티턴 세션) 등 순수 유틸
+│   └── lib/             # buildIssueMarkdown, buildIssueAdf, buildGithubIssueBody, buildLinearIssueBody, buildNotionIssueBody, submitToGithub, submitToLinear, submitToNotion(NormalizedSubmitResult), buildAiDraftPrompt, buildAiStylingPrompt, aiStylingPostProcess, ai-provider(BYOK 프로바이더 팩토리·프리셋·멀티턴 세션), video-mime(MediaRecorder mime 우선순위·확장자 매핑) 등 순수 유틸
 ├── store/               # Zustand 스토어 (editor/issues/settings/settings-ui), blob-db(IndexedDB 이미지·비디오·네트워크/콘솔 로그 저장, blobToDataUrl/dataUrlToBlob 유틸)
 │                        # settings v6: accounts: { jira?, github?, linear?, notion? } + lastSubmitFields per platform + global titlePrefix
 │                        # settings-ui v5: LlmConfig { baseUrl, apiKey, modelId } 전부 chrome.storage.local 영속
@@ -173,6 +173,7 @@ pnpm version major --no-git-tag-version   # 1.0.0 → 2.0.0 (Breaking change)
 - optional_host_permissions: `https://*/*`, `http://*/*` — BYOK LLM 프로바이더 연결 시 `chrome.permissions.request()`로 런타임 획득
 - OAuth 관련 env: `VITE_ATLASSIAN_CLIENT_ID`, `VITE_GITHUB_CLIENT_ID` (dev), `VITE_GITHUB_CLIENT_ID_PROD` (store build 시 치환), `VITE_LINEAR_CLIENT_ID` (dev), `VITE_LINEAR_CLIENT_ID_PROD` (store build 시 치환), `VITE_NOTION_CLIENT_ID`, `VITE_OAUTH_PROXY_URL` — 누락 시 해당 플랫폼 OAuth UI 자동 비활성화 (`isOAuthConfigured()` / `isGithubOAuthConfigured()` / `isLinearOAuthConfigured()` / `isNotionOAuthConfigured()`)
 - `BUGSHOT_STORE_BUILD=1`: 스토어 업로드용 빌드 (manifest `key` 제거)
+- `chrome.scripting.executeScript({world:"MAIN", func})`: 직렬화·재평가라 클로저가 안 살아남는다. 주입 함수는 self-contained(헬퍼는 nested로 inline). 현재 사용처 `github-upload.ts:pageBatchUploadFn` — 리팩터 시 실제 탭 회귀 필수. 상세: ARCHITECTURE.md 동명 섹션.
 
 ## 메모리 & 참고 문서
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background/github-upload.ts
+++ b/src/background/github-upload.ts
@@ -43,85 +43,87 @@ interface PageUploadResult {
   debug: string[];
 }
 
-async function uploadSingleFile(
-  repoId: number,
-  file: { filename: string; contentType: string; dataUrl: string },
-): Promise<{ filename: string; href: string | null; debug: string[] }> {
-  const debug: string[] = [];
-  try {
-    const match = /^data:[^;]*;base64,(.+)$/.exec(file.dataUrl);
-    if (!match) { debug.push(`${file.filename}: invalid dataUrl`); return { filename: file.filename, href: null, debug }; }
-    const binary = atob(match[1]);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    const blob = new Blob([bytes], { type: file.contentType });
-    debug.push(`${file.filename}: blob ${blob.size}b, type=${file.contentType}`);
-
-    const policyForm = new FormData();
-    policyForm.append("repository_id", String(repoId));
-    policyForm.append("name", file.filename);
-    policyForm.append("size", String(blob.size));
-    policyForm.append("content_type", file.contentType);
-
-    const policyRes = await fetch("https://github.com/upload/policies/assets", {
-      method: "POST",
-      body: policyForm,
-      headers: {
-        "GitHub-Verified-Fetch": "true",
-        "X-Requested-With": "XMLHttpRequest",
-      },
-    });
-    if (!policyRes.ok) {
-      const body = await policyRes.text().catch(() => "");
-      debug.push(`${file.filename}: policy ${policyRes.status} ${body.substring(0, 200)}`);
-      return { filename: file.filename, href: null, debug };
-    }
-    const policy = await policyRes.json();
-    debug.push(`${file.filename}: policy ok, upload_url=${policy.upload_url?.substring(0, 80)}`);
-
-    const s3Form = new FormData();
-    for (const [key, value] of Object.entries(policy.form as Record<string, string>)) {
-      s3Form.append(key, value);
-    }
-    s3Form.append("file", blob);
-
-    const s3Res = await fetch(policy.upload_url, {
-      method: "POST",
-      body: s3Form,
-      mode: "cors",
-    });
-    if (!s3Res.ok) {
-      debug.push(`${file.filename}: s3 ${s3Res.status}`);
-      return { filename: file.filename, href: null, debug };
-    }
-    debug.push(`${file.filename}: s3 ok (${s3Res.status})`);
-
-    const finalForm = new FormData();
-    finalForm.append("authenticity_token", policy.asset_upload_authenticity_token);
-    const finalUrl = new URL(policy.asset_upload_url, location.origin).href;
-
-    const finalRes = await fetch(finalUrl, {
-      method: "PUT",
-      body: finalForm,
-      headers: { Accept: "application/json" },
-    });
-    if (!finalRes.ok) {
-      debug.push(`${file.filename}: finalize ${finalRes.status}`);
-      return { filename: file.filename, href: null, debug };
-    }
-    debug.push(`${file.filename}: success href=${policy.asset.href}`);
-    return { filename: file.filename, href: policy.asset.href as string, debug };
-  } catch (e) {
-    debug.push(`${file.filename}: exception ${e}`);
-    return { filename: file.filename, href: null, debug };
-  }
-}
-
+// MUST be self-contained. chrome.scripting.executeScript serializes this via
+// Function.prototype.toString() and re-evaluates it in the target tab's MAIN
+// world — module-scope references won't survive the boundary.
 async function pageBatchUploadFn(
   repoId: number,
   files: Array<{ filename: string; contentType: string; dataUrl: string }>,
 ): Promise<PageUploadResult> {
-  const settled = await Promise.all(files.map((f) => uploadSingleFile(repoId, f)));
+  async function uploadOne(
+    file: { filename: string; contentType: string; dataUrl: string },
+  ): Promise<{ filename: string; href: string | null; debug: string[] }> {
+    const debug: string[] = [];
+    try {
+      const idx = file.dataUrl.indexOf(";base64,");
+      if (idx < 0) { debug.push(`${file.filename}: invalid dataUrl`); return { filename: file.filename, href: null, debug }; }
+      const binary = atob(file.dataUrl.slice(idx + ";base64,".length));
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const blob = new Blob([bytes], { type: file.contentType });
+      debug.push(`${file.filename}: blob ${blob.size}b, type=${file.contentType}`);
+
+      const policyForm = new FormData();
+      policyForm.append("repository_id", String(repoId));
+      policyForm.append("name", file.filename);
+      policyForm.append("size", String(blob.size));
+      policyForm.append("content_type", file.contentType);
+
+      const policyRes = await fetch("https://github.com/upload/policies/assets", {
+        method: "POST",
+        body: policyForm,
+        headers: {
+          "GitHub-Verified-Fetch": "true",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+      });
+      if (!policyRes.ok) {
+        const body = await policyRes.text().catch(() => "");
+        debug.push(`${file.filename}: policy ${policyRes.status} ${body.substring(0, 200)}`);
+        return { filename: file.filename, href: null, debug };
+      }
+      const policy = await policyRes.json();
+      debug.push(`${file.filename}: policy ok, upload_url=${policy.upload_url?.substring(0, 80)}`);
+
+      const s3Form = new FormData();
+      for (const [key, value] of Object.entries(policy.form as Record<string, string>)) {
+        s3Form.append(key, value);
+      }
+      s3Form.append("file", blob);
+
+      const s3Res = await fetch(policy.upload_url, {
+        method: "POST",
+        body: s3Form,
+        mode: "cors",
+      });
+      if (!s3Res.ok) {
+        debug.push(`${file.filename}: s3 ${s3Res.status}`);
+        return { filename: file.filename, href: null, debug };
+      }
+      debug.push(`${file.filename}: s3 ok (${s3Res.status})`);
+
+      const finalForm = new FormData();
+      finalForm.append("authenticity_token", policy.asset_upload_authenticity_token);
+      const finalUrl = new URL(policy.asset_upload_url, location.origin).href;
+
+      const finalRes = await fetch(finalUrl, {
+        method: "PUT",
+        body: finalForm,
+        headers: { Accept: "application/json" },
+      });
+      if (!finalRes.ok) {
+        debug.push(`${file.filename}: finalize ${finalRes.status}`);
+        return { filename: file.filename, href: null, debug };
+      }
+      debug.push(`${file.filename}: success href=${policy.asset.href}`);
+      return { filename: file.filename, href: policy.asset.href as string, debug };
+    } catch (e) {
+      debug.push(`${file.filename}: exception ${e}`);
+      return { filename: file.filename, href: null, debug };
+    }
+  }
+
+  const settled = await Promise.all(files.map((f) => uploadOne(f)));
   return {
     files: settled.map((r) => ({ filename: r.filename, href: r.href })),
     debug: settled.flatMap((r) => r.debug),

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,9 +7,11 @@ import { LinearError } from "./linear-api";
 import { NotionError } from "./notion-api";
 import { handleMessage } from "./messages";
 import { OAuthError } from "./oauth";
+import { pruneOrphanPendingLogsOncePerSession } from "@/lib/pending-log-prune";
 import { activateTab, setupTabBindings } from "./tab-bindings";
 
 initBgLocale();
+void pruneOrphanPendingLogsOncePerSession();
 
 function friendlyError(error: unknown): string {
   if (error instanceof TypeError && error.message === "Failed to fetch") {

--- a/src/background/messages.ts
+++ b/src/background/messages.ts
@@ -338,7 +338,11 @@ async function submitIssue(
         }
       }
 
-      const videoFile = uploadMap.get("recording.webm");
+      // recording.{webm,mp4} — extension follows whatever the MediaRecorder produced.
+      let videoFile: UploadedFile | undefined;
+      for (const [name, file] of uploadMap) {
+        if (/^recording\.(webm|mp4)$/i.test(name)) { videoFile = file; break; }
+      }
       const videoPlaceholderIdx = content.findIndex(
         (n) => {
           const node = n as { type: string; content?: { text?: string }[] };

--- a/src/content/console-recorder.ts
+++ b/src/content/console-recorder.ts
@@ -104,7 +104,6 @@ function consoleRecorderScript(): void {
   function pushEntry(level: Level, args: string, stack?: string): void {
     if (!recording) return;
     totalSeen++;
-    if (buffer.length >= MAX_ENTRIES) return;
     const entry: CapturedEntry = {
       id: genId(),
       level,
@@ -113,7 +112,9 @@ function consoleRecorderScript(): void {
       pageUrl: location.href,
     };
     if (stack) entry.stack = stack;
+    // 버그 재현 시 가치 있는 신호는 후반부이므로 cap 도달 시 oldest를 버리는 FIFO.
     buffer.push(entry);
+    if (buffer.length > MAX_ENTRIES) buffer.shift();
   }
 
   // error/warn은 wrap하지 않는다. 페이지가 console.error/warn을 호출하면 native 호출 시점의
@@ -288,6 +289,8 @@ function consoleRecorderScript(): void {
   function clearBuffer(): void {
     buffer.length = 0;
     totalSeen = 0;
+    counters.clear();
+    timers.clear();
   }
 
   function detachSentinelListeners(): void {

--- a/src/content/network-recorder.ts
+++ b/src/content/network-recorder.ts
@@ -6,6 +6,7 @@ function networkRecorderScript(): void {
   if ((window as any)[CTRL_KEY]) return; // 이미 초기화됨
 
   const MEMORY_CAP = 50 * 1024 * 1024; // 50 MB
+  const MAX_REQUEST_ENTRIES = 5000;
   const SET_SENTINEL_EVENT = "__bugshot_net_setSentinel__";
 
   const MASKED_HEADERS = new Set([
@@ -186,6 +187,23 @@ function networkRecorderScript(): void {
     }
   }
 
+  // FIFO eviction — body 없는 요청(HEAD/204/binary)이 폭증해도 buffer 자체 길이가 무한해지지 않도록.
+  // 버그 재현 시나리오에서 가치 있는 신호는 후반부이므로 oldest를 버린다.
+  function enforceEntryCap(): void {
+    while (buffer.length > MAX_REQUEST_ENTRIES) {
+      const evicted = buffer.shift();
+      if (!evicted) break;
+      memoryUsed -= estimateBodySize(evicted.requestBody);
+      memoryUsed -= estimateBodySize(evicted.responseBody);
+      warnings.add("ENTRY_CAPPED");
+    }
+  }
+
+  function pushEntry(entry: CapturedRequest): void {
+    buffer.push(entry);
+    enforceEntryCap();
+  }
+
   async function readBodyStreaming(response: Response, contentType: string): Promise<ReqBody> {
     if (!response.body) return { kind: "stream", contentType };
     const reader = response.body.getReader();
@@ -272,7 +290,7 @@ function networkRecorderScript(): void {
       phase: "pending",
     };
     memoryUsed += estimateBodySize(entry.requestBody);
-    buffer.push(entry);
+    pushEntry(entry);
     enforceMemoryCap();
 
     let response: Response;
@@ -402,7 +420,7 @@ function networkRecorderScript(): void {
       phase: "pending",
     };
     memoryUsed += estimateBodySize(entry.requestBody);
-    buffer.push(entry);
+    pushEntry(entry);
     enforceMemoryCap();
 
     // load / error / abort / timeout이 한 요청에 동시에 발화되는 일은 없지만,
@@ -511,7 +529,7 @@ function networkRecorderScript(): void {
           phase: queued ? "complete" : "error",
         };
         memoryUsed += estimateBodySize(entry.requestBody);
-        buffer.push(entry);
+        pushEntry(entry);
         enforceMemoryCap();
       }
       return queued;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -339,7 +339,7 @@ const en = {
   "md.section.after": "After",
   "md.section.expectedResult": "Expected Result",
   "md.section.notes": "Notes",
-  "md.videoAttached": "(recording.webm)",
+  "md.videoAttached": "(See attached recording)",
   "md.imageAttached": "(See attached image)",
   "md.column.property": "Property",
   "md.noValue": "(none)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -337,7 +337,7 @@ const ko = {
   "md.section.after": "After",
   "md.section.expectedResult": "기대 결과",
   "md.section.notes": "비고",
-  "md.videoAttached": "(recording.webm 참조)",
+  "md.videoAttached": "(첨부 녹화 파일 참조)",
   "md.imageAttached": "(첨부 이미지 참조)",
   "md.column.property": "속성",
   "md.noValue": "(없음)",

--- a/src/lib/__tests__/pending-log-prune.test.ts
+++ b/src/lib/__tests__/pending-log-prune.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { findOrphanPendingKeys } from "../pending-log-prune";
+
+describe("findOrphanPendingKeys", () => {
+  it("returns pending keys whose tabId is not in activeTabIds", () => {
+    const keys = ["pending:123", "pending:456", "pending:789"];
+    const active = new Set([123, 789]);
+    expect(findOrphanPendingKeys(keys, active)).toEqual(["pending:456"]);
+  });
+
+  it("ignores non-pending keys (issue blob keys)", () => {
+    const keys = [
+      "abc123-issue-id",
+      "abc123-issue-id:before",
+      "pending:42",
+    ];
+    expect(findOrphanPendingKeys(keys, new Set())).toEqual(["pending:42"]);
+  });
+
+  it("empty active set: all pending keys are orphans", () => {
+    expect(
+      findOrphanPendingKeys(["pending:1", "pending:2"], new Set()),
+    ).toEqual(["pending:1", "pending:2"]);
+  });
+
+  it("all tabIds active: no orphans", () => {
+    expect(
+      findOrphanPendingKeys(["pending:1", "pending:2"], new Set([1, 2])),
+    ).toEqual([]);
+  });
+
+  it("malformed pending key (non-numeric tabId) treated as orphan", () => {
+    expect(
+      findOrphanPendingKeys(["pending:abc", "pending:"], new Set([0])),
+    ).toEqual(["pending:abc", "pending:"]);
+  });
+
+  it("float tabId treated as orphan (Number.isInteger guard)", () => {
+    expect(findOrphanPendingKeys(["pending:1.5"], new Set([1]))).toEqual([
+      "pending:1.5",
+    ]);
+  });
+
+  it("empty key list", () => {
+    expect(findOrphanPendingKeys([], new Set([1]))).toEqual([]);
+  });
+});

--- a/src/lib/pending-log-prune.ts
+++ b/src/lib/pending-log-prune.ts
@@ -1,0 +1,70 @@
+import {
+  deleteConsoleLog,
+  deleteNetworkLog,
+  getConsoleLogKeys,
+  getNetworkLogKeys,
+} from "@/store/blob-db";
+
+const PENDING_PREFIX = "pending:";
+
+export function findOrphanPendingKeys(
+  keys: string[],
+  activeTabIds: Set<number>,
+): string[] {
+  const orphans: string[] = [];
+  for (const key of keys) {
+    if (!key.startsWith(PENDING_PREFIX)) continue;
+    const raw = key.slice(PENDING_PREFIX.length);
+    if (raw === "") {
+      orphans.push(key);
+      continue;
+    }
+    const tabId = Number(raw);
+    if (!Number.isInteger(tabId)) {
+      orphans.push(key);
+      continue;
+    }
+    if (!activeTabIds.has(tabId)) orphans.push(key);
+  }
+  return orphans;
+}
+
+async function getActiveTabIds(): Promise<Set<number>> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    const ids = new Set<number>();
+    for (const t of tabs) if (t.id != null) ids.add(t.id);
+    return ids;
+  } catch {
+    return new Set();
+  }
+}
+
+export async function pruneOrphanPendingLogs(): Promise<void> {
+  const activeTabIds = await getActiveTabIds();
+  const [networkKeys, consoleKeys] = await Promise.all([
+    getNetworkLogKeys(),
+    getConsoleLogKeys(),
+  ]);
+  const networkOrphans = findOrphanPendingKeys(networkKeys, activeTabIds);
+  const consoleOrphans = findOrphanPendingKeys(consoleKeys, activeTabIds);
+  await Promise.all([
+    ...networkOrphans.map((k) => deleteNetworkLog(k).catch(() => {})),
+    ...consoleOrphans.map((k) => deleteConsoleLog(k).catch(() => {})),
+  ]);
+}
+
+const SESSION_FLAG = "pendingPrunedAt";
+
+// SW가 idle suspend→wake 사이클을 반복하지만, 같은 chrome.storage.session 인스턴스 동안엔
+// 1회만 돌도록 가드. 브라우저 종료까지가 세션 경계.
+export async function pruneOrphanPendingLogsOncePerSession(): Promise<void> {
+  try {
+    const data = await chrome.storage.session.get(SESSION_FLAG);
+    if (data[SESSION_FLAG]) return;
+    await chrome.storage.session.set({ [SESSION_FLAG]: Date.now() });
+  } catch {
+    return;
+  }
+  await pruneOrphanPendingLogs();
+}

--- a/src/sidepanel/lib/__tests__/video-mime.test.ts
+++ b/src/sidepanel/lib/__tests__/video-mime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  pickVideoRecorderMime,
+  recordingFilename,
+  videoMimeToExt,
+} from "../video-mime";
+
+describe("videoMimeToExt", () => {
+  it("video/mp4 → .mp4", () => {
+    expect(videoMimeToExt("video/mp4")).toBe(".mp4");
+  });
+
+  it("video/mp4 with codecs → .mp4", () => {
+    expect(videoMimeToExt('video/mp4;codecs="avc1.42E01E,mp4a.40.2"')).toBe(".mp4");
+  });
+
+  it("video/webm → .webm", () => {
+    expect(videoMimeToExt("video/webm")).toBe(".webm");
+  });
+
+  it("video/webm with codecs → .webm", () => {
+    expect(videoMimeToExt("video/webm;codecs=vp9")).toBe(".webm");
+  });
+
+  it("empty mime defaults to .webm (legacy blobs)", () => {
+    expect(videoMimeToExt("")).toBe(".webm");
+  });
+
+  it("unknown mime defaults to .webm", () => {
+    expect(videoMimeToExt("video/x-matroska")).toBe(".webm");
+  });
+
+  it("case-insensitive", () => {
+    expect(videoMimeToExt("VIDEO/MP4")).toBe(".mp4");
+    expect(videoMimeToExt("Video/Webm;Codecs=Vp9")).toBe(".webm");
+  });
+});
+
+describe("recordingFilename", () => {
+  it("derives filename from mp4 mime", () => {
+    expect(recordingFilename("video/mp4")).toBe("recording.mp4");
+  });
+
+  it("derives filename from webm mime", () => {
+    expect(recordingFilename("video/webm;codecs=vp9")).toBe("recording.webm");
+  });
+
+  it("defaults to recording.webm for empty mime (legacy)", () => {
+    expect(recordingFilename("")).toBe("recording.webm");
+  });
+});
+
+describe("pickVideoRecorderMime", () => {
+  const supported = (whitelist: string[]) => (mime: string) =>
+    whitelist.includes(mime);
+
+  it("picks mp4 first when supported", () => {
+    expect(
+      pickVideoRecorderMime(
+        supported([
+          'video/mp4;codecs="avc1.42E01E,mp4a.40.2"',
+          "video/webm;codecs=vp9",
+          "video/webm",
+        ]),
+      ),
+    ).toBe('video/mp4;codecs="avc1.42E01E,mp4a.40.2"');
+  });
+
+  it("falls back to plain video/mp4 when codec-specific not supported", () => {
+    expect(
+      pickVideoRecorderMime(
+        supported(["video/mp4", "video/webm"]),
+      ),
+    ).toBe("video/mp4");
+  });
+
+  it("falls back to webm when mp4 not supported", () => {
+    expect(
+      pickVideoRecorderMime(
+        supported(["video/webm;codecs=vp9", "video/webm"]),
+      ),
+    ).toBe("video/webm;codecs=vp9");
+  });
+
+  it("returns empty string when nothing supported", () => {
+    expect(pickVideoRecorderMime(() => false)).toBe("");
+  });
+
+  it("respects priority order: mp4 codec-specific > mp4 bare > webm vp9 > webm vp8 > webm bare", () => {
+    // Only the last two supported: should prefer vp9 over vp8 (priority order).
+    expect(
+      pickVideoRecorderMime(
+        supported(["video/webm;codecs=vp9", "video/webm;codecs=vp8"]),
+      ),
+    ).toBe("video/webm;codecs=vp9");
+  });
+});

--- a/src/sidepanel/lib/submitToGithub.ts
+++ b/src/sidepanel/lib/submitToGithub.ts
@@ -32,6 +32,7 @@ function githubFilename(name: string): string {
 function guessMime(filename: string): string {
   if (filename.endsWith(".webp")) return "image/webp";
   if (filename.endsWith(".webm")) return "video/webm";
+  if (filename.endsWith(".mp4")) return "video/mp4";
   if (filename.endsWith(".md")) return "text/markdown";
   if (filename.endsWith(".json")) return "application/json";
   return "application/octet-stream";

--- a/src/sidepanel/lib/submitToLinear.ts
+++ b/src/sidepanel/lib/submitToLinear.ts
@@ -28,6 +28,7 @@ export interface LinearSubmitInput {
 function guessMime(filename: string): string {
   if (filename.endsWith(".webp")) return "image/webp";
   if (filename.endsWith(".webm")) return "video/webm";
+  if (filename.endsWith(".mp4")) return "video/mp4";
   if (filename.endsWith(".md")) return "text/markdown";
   if (filename.endsWith(".har")) return "application/json";
   if (filename.endsWith(".json")) return "application/json";

--- a/src/sidepanel/lib/submitToNotion.ts
+++ b/src/sidepanel/lib/submitToNotion.ts
@@ -28,6 +28,7 @@ export interface NotionSubmitInput {
 function guessMime(filename: string): string {
   if (filename.endsWith(".webp")) return "image/webp";
   if (filename.endsWith(".webm")) return "video/webm";
+  if (filename.endsWith(".mp4")) return "video/mp4";
   if (filename.endsWith(".png")) return "image/png";
   if (filename.endsWith(".jpg") || filename.endsWith(".jpeg")) return "image/jpeg";
   if (filename.endsWith(".md")) return "text/markdown";

--- a/src/sidepanel/lib/video-mime.ts
+++ b/src/sidepanel/lib/video-mime.ts
@@ -1,0 +1,30 @@
+// MediaRecorder mime priority. mp4 first so Jira's media services can
+// transcode quickly (webm processing is slow / fails in many workspaces).
+// Fall back to webm on browsers where mp4 container isn't supported.
+const RECORDER_MIME_CANDIDATES = [
+  'video/mp4;codecs="avc1.42E01E,mp4a.40.2"',
+  "video/mp4",
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm",
+] as const;
+
+export function pickVideoRecorderMime(
+  isSupported: (mime: string) => boolean = (m) =>
+    typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported(m),
+): string {
+  for (const mime of RECORDER_MIME_CANDIDATES) {
+    if (isSupported(mime)) return mime;
+  }
+  return "";
+}
+
+export function videoMimeToExt(mime: string): string {
+  const lower = mime.toLowerCase();
+  if (lower.startsWith("video/mp4")) return ".mp4";
+  return ".webm";
+}
+
+export function recordingFilename(mime: string, base = "recording"): string {
+  return `${base}${videoMimeToExt(mime)}`;
+}

--- a/src/sidepanel/tabs/DraftDetailDialog.tsx
+++ b/src/sidepanel/tabs/DraftDetailDialog.tsx
@@ -48,6 +48,7 @@ import { sendBg, type JiraSubmitResult } from "@/types/messages";
 import { submitToGithub, type GithubFileInput } from "../lib/submitToGithub";
 import { submitToLinear, type LinearFileInput } from "../lib/submitToLinear";
 import { submitToNotion, type NotionFileInput } from "../lib/submitToNotion";
+import { recordingFilename } from "../lib/video-mime";
 import {
   initialGhFields,
   type GithubIssueFieldsValue,
@@ -285,7 +286,7 @@ export function DraftDetailDialog({
     if (isVideo) {
       const blob = await getVideoBlob(issue.id);
       if (blob) {
-        attachments.push({ filename: "recording.webm", dataUrl: await blobToDataUrl(blob) });
+        attachments.push({ filename: recordingFilename(blob.type), dataUrl: await blobToDataUrl(blob) });
       }
       if (networkLog) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
@@ -368,7 +369,7 @@ export function DraftDetailDialog({
 
     if (isVideo) {
       const blob = await getVideoBlob(issue.id);
-      if (blob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(blob) };
+      if (blob) video = { filename: recordingFilename(blob.type), dataUrl: await blobToDataUrl(blob) };
       if (networkLog) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });
@@ -440,7 +441,7 @@ export function DraftDetailDialog({
 
     if (isVideo) {
       const blob = await getVideoBlob(issue.id);
-      if (blob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(blob) };
+      if (blob) video = { filename: recordingFilename(blob.type), dataUrl: await blobToDataUrl(blob) };
       if (netLog) {
         const harBlob = new Blob([serializeHar(buildHar(netLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });
@@ -523,7 +524,7 @@ export function DraftDetailDialog({
 
     if (isVideo) {
       const blob = await getVideoBlob(issue.id);
-      if (blob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(blob) };
+      if (blob) video = { filename: recordingFilename(blob.type), dataUrl: await blobToDataUrl(blob) };
       if (networkLog) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });

--- a/src/sidepanel/tabs/DraftingPanel.tsx
+++ b/src/sidepanel/tabs/DraftingPanel.tsx
@@ -512,17 +512,17 @@ function OrderedListEditor({
 }
 
 function VideoPreview({ blob, thumbnail }: { blob: Blob | null; thumbnail: string | null }) {
-  const urlRef = useRef<string | null>(null);
-  const src = blob ? (urlRef.current ??= URL.createObjectURL(blob)) : null;
+  const [src, setSrc] = useState<string | null>(null);
 
   useEffect(() => {
-    return () => {
-      if (urlRef.current) {
-        URL.revokeObjectURL(urlRef.current);
-        urlRef.current = null;
-      }
-    };
-  }, []);
+    if (!blob) {
+      setSrc(null);
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [blob]);
 
   return (
     <div className="space-y-1.5">

--- a/src/sidepanel/tabs/IssueCreateModal.tsx
+++ b/src/sidepanel/tabs/IssueCreateModal.tsx
@@ -71,6 +71,7 @@ import type { NormalizedSubmitResult } from "@/types/platform";
 import { submitToGithub, type GithubFileInput } from "../lib/submitToGithub";
 import { submitToLinear, type LinearFileInput } from "../lib/submitToLinear";
 import { submitToNotion, type NotionFileInput } from "../lib/submitToNotion";
+import { recordingFilename } from "../lib/video-mime";
 import {
   GithubIssueFields,
   initialGhFields,
@@ -267,7 +268,7 @@ export function IssueCreateModal() {
 
     if (captureMode === "video") {
       if (videoBlob) {
-        attachments.push({ filename: "recording.webm", dataUrl: await blobToDataUrl(videoBlob) });
+        attachments.push({ filename: recordingFilename(videoBlob.type), dataUrl: await blobToDataUrl(videoBlob) });
       }
       if (networkLog && networkLogAttach && networkLog.captured > 0) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
@@ -337,7 +338,7 @@ export function IssueCreateModal() {
     const logs: GithubFileInput[] = [];
 
     if (captureMode === "video") {
-      if (videoBlob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(videoBlob) };
+      if (videoBlob) video = { filename: recordingFilename(videoBlob.type), dataUrl: await blobToDataUrl(videoBlob) };
       if (networkLog && networkLogAttach && networkLog.captured > 0) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });
@@ -396,7 +397,7 @@ export function IssueCreateModal() {
     const logs: LinearFileInput[] = [];
 
     if (captureMode === "video") {
-      if (videoBlob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(videoBlob) };
+      if (videoBlob) video = { filename: recordingFilename(videoBlob.type), dataUrl: await blobToDataUrl(videoBlob) };
       if (networkLog && networkLogAttach && networkLog.captured > 0) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });
@@ -464,7 +465,7 @@ export function IssueCreateModal() {
     const logs: NotionFileInput[] = [];
 
     if (captureMode === "video") {
-      if (videoBlob) video = { filename: "recording.webm", dataUrl: await blobToDataUrl(videoBlob) };
+      if (videoBlob) video = { filename: recordingFilename(videoBlob.type), dataUrl: await blobToDataUrl(videoBlob) };
       if (networkLog && networkLogAttach && networkLog.captured > 0) {
         const harBlob = new Blob([serializeHar(buildHar(networkLog))], { type: "application/json" });
         logs.push({ filename: "network-log.har", dataUrl: await blobToDataUrl(harBlob) });

--- a/src/sidepanel/tabs/IssueListTab.tsx
+++ b/src/sidepanel/tabs/IssueListTab.tsx
@@ -196,19 +196,6 @@ export function IssueListTab() {
     );
   }
 
-  if (displayable.length === 0) {
-    return (
-      <PageShell>
-        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-5 text-center">
-          <div className="mb-3 rounded-full bg-muted p-3">
-            <Inbox className="h-6 w-6 text-muted-foreground" />
-          </div>
-          <h3 className="text-[18px] font-semibold">{t("issueList.empty")}</h3>
-        </div>
-      </PageShell>
-    );
-  }
-
   return (
     <PageShell>
       <div className="shrink-0 border-b border-border px-4 py-4">
@@ -240,7 +227,14 @@ export function IssueListTab() {
           </div>
         </div>
       </div>
-      {filtered.length === 0 ? (
+      {displayable.length === 0 ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-5 text-center">
+          <div className="mb-3 rounded-full bg-muted p-3">
+            <Inbox className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <h3 className="text-[18px] font-semibold">{t("issueList.empty")}</h3>
+        </div>
+      ) : filtered.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-5 text-center">
           <div className="mb-3 rounded-full bg-muted p-3">
             <SearchX className="h-6 w-6 text-muted-foreground" />
@@ -269,46 +263,48 @@ export function IssueListTab() {
         ))}
         </PageScroll>
       )}
-      <PageFooter>
-        <div className="flex justify-between">
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="outline" className="text-destructive">
-                {t("issueList.deleteAll")}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>{t("issueList.deleteAll.title")}</AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t("issueList.deleteAll.body")}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t("common.close")}</AlertDialogCancel>
-                <AlertDialogAction onClick={clearIssues}>
+      {displayable.length > 0 && (
+        <PageFooter>
+          <div className="flex justify-between">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" className="text-destructive">
                   {t("issueList.deleteAll")}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-          <Button
-            variant="outline"
-            disabled={isRefreshing || refreshableCount === 0}
-            onClick={handleRefresh}
-            className="relative"
-          >
-            {isRefreshing && (
-              <span className="absolute inset-0 flex items-center justify-center">
-                <Loader2 className="h-4 w-4 animate-spin" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t("issueList.deleteAll.title")}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t("issueList.deleteAll.body")}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t("common.close")}</AlertDialogCancel>
+                  <AlertDialogAction onClick={clearIssues}>
+                    {t("issueList.deleteAll")}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <Button
+              variant="outline"
+              disabled={isRefreshing || refreshableCount === 0}
+              onClick={handleRefresh}
+              className="relative"
+            >
+              {isRefreshing && (
+                <span className="absolute inset-0 flex items-center justify-center">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                </span>
+              )}
+              <span className={isRefreshing ? "opacity-0" : undefined}>
+                {t("issueList.refresh")}
               </span>
-            )}
-            <span className={isRefreshing ? "opacity-0" : undefined}>
-              {t("issueList.refresh")}
-            </span>
-          </Button>
-        </div>
-      </PageFooter>
+            </Button>
+          </div>
+        </PageFooter>
+      )}
       <DraftDetailDialog
         issue={activeDraft}
         open={!!activeDraft}

--- a/src/sidepanel/tabs/PreviewPanel.tsx
+++ b/src/sidepanel/tabs/PreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Check, Copy, Info } from "lucide-react";
 import { formatTimestamp } from "../lib/formatTimestamp";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -320,17 +320,17 @@ export function PreviewPanel() {
 }
 
 function PreviewVideo({ blob, thumbnail }: { blob: Blob | null; thumbnail: string | null }) {
-  const urlRef = useRef<string | null>(null);
-  const src = blob ? (urlRef.current ??= URL.createObjectURL(blob)) : null;
+  const [src, setSrc] = useState<string | null>(null);
 
   useEffect(() => {
-    return () => {
-      if (urlRef.current) {
-        URL.revokeObjectURL(urlRef.current);
-        urlRef.current = null;
-      }
-    };
-  }, []);
+    if (!blob) {
+      setSrc(null);
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [blob]);
 
   if (src) return <video src={src} controls className="w-full rounded-lg border" />;
   if (thumbnail) return <img src={thumbnail} alt="Recording thumbnail" className="w-full rounded-lg border" />;

--- a/src/sidepanel/video-recorder.ts
+++ b/src/sidepanel/video-recorder.ts
@@ -3,6 +3,7 @@ import {
   stopConsoleRecorder,
   stopNetworkRecorder,
 } from "./picker-control";
+import { pickVideoRecorderMime } from "./lib/video-mime";
 
 const MAX_DURATION_SEC = 60;
 
@@ -16,17 +17,6 @@ interface RecorderState {
 }
 
 let state: RecorderState | null = null;
-
-function pickMimeType(): string {
-  for (const mime of [
-    "video/webm;codecs=vp9",
-    "video/webm;codecs=vp8",
-    "video/webm",
-  ]) {
-    if (MediaRecorder.isTypeSupported(mime)) return mime;
-  }
-  return "";
-}
 
 export async function startRecording(tabId: number): Promise<void> {
   if (state) cancelRecording();
@@ -53,7 +43,7 @@ export async function startRecording(tabId: number): Promise<void> {
     },
   } as MediaStreamConstraints);
 
-  const mimeType = pickMimeType();
+  const mimeType = pickVideoRecorderMime();
   const recorder = new MediaRecorder(stream, {
     ...(mimeType ? { mimeType } : {}),
     videoBitsPerSecond: 1_500_000,
@@ -70,7 +60,12 @@ export async function startRecording(tabId: number): Promise<void> {
     window.clearTimeout(s.maxTimer);
     s.stream.getTracks().forEach((t) => t.stop());
 
-    const blob = new Blob(chunks, { type: "video/webm" });
+    // Strip codec parameter — mp4 recorder mime contains
+    // `codecs="avc1.42E01E,mp4a.40.2"` whose comma breaks downstream data URL
+    // parsers (GitHub asset upload uses a strict regex).
+    const recorderMime = s.recorder.mimeType || mimeType || "video/webm";
+    const blobType = recorderMime.split(";")[0] || "video/webm";
+    const blob = new Blob(chunks, { type: blobType });
     const localTabId = s.tabId;
     state = null;
 


### PR DESCRIPTION
## Summary

- **fix(github-upload)**: GitHub inline issue uploads were silently broken since v1.1.2. `pageBatchUploadFn` referenced module-scope `uploadSingleFile`, but `chrome.scripting.executeScript({world:"MAIN"})` serializes via `Function.prototype.toString()` and re-evaluates in the page context — closures don't survive. Every upload returned `null` href and fell back to the "GitHub doesn't support inline attachments" message. Now self-contained with nested helpers.
- **fix(recorder)**: Plug leak vectors in console/network recorders and pending logs (5000-entry FIFO + 50MB body cap on network; 2000-entry FIFO + counters/timers reset on console; SW-boot orphan pending prune).
- **feat(video)**: MediaRecorder prefers `video/mp4` (H.264/AAC) over webm so Jira's media service transcodes inline previews immediately. webm fallback preserved for browsers without mp4 container support. Existing webm blobs persist unchanged. mp4 codec parameters stripped before Blob creation so downstream data URL parsers stay robust.
- **feat(issue-list)**: Filter and search header always renders, even on empty list. Footer (delete all / refresh) still hides when there's nothing actionable.
- **docs**: ARCHITECTURE.md gains a section on the `chrome.scripting.executeScript` MAIN world closure rule (with the 1.1.2–1.1.4 latent regression as the case study). CLAUDE.md pointer + `video-mime` helper listed in sidepanel/lib.

## Test plan

- [x] `pnpm typecheck` + `pnpm test` (580 passed)
- [x] `pnpm build` (clean)
- [x] mp4 recording → Jira/Linear/Notion inline preview (no fallback card)
- [x] mp4 recording → GitHub `<video>` inline playback (regression verified fixed)
- [x] Empty issue list shows filter/search header
- [ ] Legacy webm draft submit still works on platforms (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)