### PR TITLE
v1.1.6 — UI polish, tab unification, settings improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
       className,
     )}
     {...props}

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -21,7 +21,11 @@ const ToggleGroup = React.forwardRef<
 >(({ className, variant, size, children, ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
-    className={cn("flex items-center justify-center gap-1", className)}
+    className={cn(
+      "flex items-center justify-center",
+      variant === "segment" || variant === "underline" ? "gap-0" : "gap-1",
+      className,
+    )}
     {...props}
   >
     <ToggleGroupContext.Provider value={{ variant, size }}>

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -5,18 +5,22 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: "bg-accent",
         outline:
           "border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
+        segment:
+          "border border-input bg-muted shadow-sm hover:bg-muted hover:text-foreground rounded-none -ml-px first:ml-0 first:rounded-l-md last:rounded-r-md data-[state=on]:bg-background data-[state=on]:text-foreground",
+        underline:
+          "bg-transparent rounded-none border-b-2 border-transparent shadow-none hover:bg-transparent hover:text-foreground data-[state=on]:border-primary data-[state=on]:bg-transparent data-[state=on]:shadow-none",
       },
       size: {
-        default: "h-9 px-2 min-w-9",
-        sm: "h-8 px-1.5 min-w-8",
-        lg: "h-10 px-2.5 min-w-10",
+        default: "h-9 px-3 min-w-9",
+        sm: "h-8 px-2.5 min-w-8",
+        lg: "h-10 px-3.5 min-w-10",
       },
     },
     defaultVariants: {

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -220,7 +220,7 @@ const ko = {
   // Settings tabs
   "settings.tab.issue": "이슈 설정",
   "settings.tab.ai": "AI 모델",
-  "settings.tab.general": "기타",
+  "settings.tab.general": "일반",
 
   // LLM BYOK
   "llm.onboarding.title": "AI 모델을 연결하세요",

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/sonner";
 import { PICKER_PORT_NAME, PANEL_PORT_PREFIX } from "@/lib/session-keys";
@@ -164,27 +164,27 @@ export default function App() {
     <TabNavContext.Provider value={setTab}>
     <div className="flex h-screen flex-col">
       <div className="flex min-h-0 flex-1 flex-col gap-0">
-        <div className="border-b">
-          <ToggleGroup type="single" variant="segment" value={tab}
-            className="mx-4 my-5 grid w-auto grid-cols-4"
-            onValueChange={(v) => { if (v) setTab(v); }}>
-            <ToggleGroupItem value="debug" className="gap-1.5">
-              <TerminalSquare className="h-3.5 w-3.5" />
-              {t("app.tab.debug")}
-            </ToggleGroupItem>
-            <ToggleGroupItem value="issue-list" className="gap-1.5">
-              <List className="h-3.5 w-3.5" />
-              {t("app.tab.issueList")}
-            </ToggleGroupItem>
-            <ToggleGroupItem value="integrations" className="gap-1.5">
-              <Blocks className="h-3.5 w-3.5" />
-              {t("app.tab.integrations")}
-            </ToggleGroupItem>
-            <ToggleGroupItem value="settings" className="gap-1.5">
-              <Settings className="h-3.5 w-3.5" />
-              {t("app.tab.settings")}
-            </ToggleGroupItem>
-          </ToggleGroup>
+        <div className="border-b px-4 py-4">
+          <Tabs value={tab} onValueChange={(v) => setTab(v)}>
+            <TabsList className="grid h-9 w-full grid-cols-4">
+              <TabsTrigger value="debug" className="gap-1.5">
+                <TerminalSquare className="h-3.5 w-3.5" />
+                {t("app.tab.debug")}
+              </TabsTrigger>
+              <TabsTrigger value="issue-list" className="gap-1.5">
+                <List className="h-3.5 w-3.5" />
+                {t("app.tab.issueList")}
+              </TabsTrigger>
+              <TabsTrigger value="integrations" className="gap-1.5">
+                <Blocks className="h-3.5 w-3.5" />
+                {t("app.tab.integrations")}
+              </TabsTrigger>
+              <TabsTrigger value="settings" className="gap-1.5">
+                <Settings className="h-3.5 w-3.5" />
+                {t("app.tab.settings")}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
 
         <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", tab !== "debug" && "hidden")}>

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -10,7 +10,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/sonner";
 import { PICKER_PORT_NAME, PANEL_PORT_PREFIX } from "@/lib/session-keys";
 import { useEditorStore } from "@/store/editor-store";
@@ -162,60 +163,46 @@ export default function App() {
   return (
     <TabNavContext.Provider value={setTab}>
     <div className="flex h-screen flex-col">
-      <Tabs
-        value={tab}
-        onValueChange={setTab}
-        className="flex min-h-0 flex-1 flex-col gap-0"
-      >
+      <div className="flex min-h-0 flex-1 flex-col gap-0">
         <div className="border-b">
-          <TabsList className="mx-4 my-5 grid h-9 w-auto grid-cols-4">
-            <TabsTrigger value="debug" className="gap-1.5">
+          <ToggleGroup type="single" variant="segment" value={tab}
+            className="mx-4 my-5 grid w-auto grid-cols-4"
+            onValueChange={(v) => { if (v) setTab(v); }}>
+            <ToggleGroupItem value="debug" className="gap-1.5">
               <TerminalSquare className="h-3.5 w-3.5" />
               {t("app.tab.debug")}
-            </TabsTrigger>
-            <TabsTrigger value="issue-list" className="gap-1.5">
+            </ToggleGroupItem>
+            <ToggleGroupItem value="issue-list" className="gap-1.5">
               <List className="h-3.5 w-3.5" />
               {t("app.tab.issueList")}
-            </TabsTrigger>
-            <TabsTrigger value="integrations" className="gap-1.5">
+            </ToggleGroupItem>
+            <ToggleGroupItem value="integrations" className="gap-1.5">
               <Blocks className="h-3.5 w-3.5" />
               {t("app.tab.integrations")}
-            </TabsTrigger>
-            <TabsTrigger value="settings" className="gap-1.5">
+            </ToggleGroupItem>
+            <ToggleGroupItem value="settings" className="gap-1.5">
               <Settings className="h-3.5 w-3.5" />
               {t("app.tab.settings")}
-            </TabsTrigger>
-          </TabsList>
+            </ToggleGroupItem>
+          </ToggleGroup>
         </div>
 
-        <TabsContent
-          value="debug"
-          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-        >
+        <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", tab !== "debug" && "hidden")}>
           <DebugTab />
-        </TabsContent>
+        </div>
 
-        <TabsContent
-          value="issue-list"
-          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-        >
+        <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", tab !== "issue-list" && "hidden")}>
           <IssueListTab />
-        </TabsContent>
+        </div>
 
-        <TabsContent
-          value="integrations"
-          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-        >
+        <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", tab !== "integrations" && "hidden")}>
           <IntegrationsTab />
-        </TabsContent>
+        </div>
 
-        <TabsContent
-          value="settings"
-          className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden data-[state=inactive]:hidden"
-        >
+        <div className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", tab !== "settings" && "hidden")}>
           <SettingsTab />
-        </TabsContent>
-      </Tabs>
+        </div>
+      </div>
 
       <AlertDialog
         open={oauthExpiredPlatform != null}

--- a/src/sidepanel/components/ConsoleLogContent.tsx
+++ b/src/sidepanel/components/ConsoleLogContent.tsx
@@ -13,6 +13,7 @@ const CONSOLE_FILTERS: ConsoleFilter[] = ["all", "error", "warn", "info", "debug
 interface ConsoleLogContentProps {
   entries: ConsoleEntry[];
   startedAt: number;
+  flush?: boolean;
 }
 
 function levelColor(level: ConsoleLevel): string {
@@ -61,7 +62,7 @@ function formatRelativeTime(ts: number, baseTs: number): string {
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
 }
 
-export function ConsoleLogContent({ entries, startedAt }: ConsoleLogContentProps) {
+export function ConsoleLogContent({ entries, startedAt, flush }: ConsoleLogContentProps) {
   const t = useT();
   const [filter, setFilter] = useState<ConsoleFilter>("all");
   const [query, setQuery] = useState("");
@@ -87,9 +88,9 @@ export function ConsoleLogContent({ entries, startedAt }: ConsoleLogContentProps
   }, [entries, filter, query]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border">
+    <div className={`flex min-h-0 flex-1 flex-col overflow-hidden${flush ? "" : " rounded-lg border"}`}>
       <Tabs value={filter} onValueChange={(v) => setFilter(v as ConsoleFilter)}>
-        <div className="flex items-center gap-3 border-b p-2">
+        <div className={`flex items-center gap-3 border-b${flush ? " px-4 py-4" : " p-2"}`}>
           <TabsList>
             {availableFilters.map((f) => (
               <TabsTrigger key={f} value={f}>

--- a/src/sidepanel/components/NetworkLogContent.tsx
+++ b/src/sidepanel/components/NetworkLogContent.tsx
@@ -17,6 +17,7 @@ const REQUEST_FILTERS: RequestFilter[] = ["all", "json", "js", "css", "img", "fo
 
 interface NetworkLogContentProps {
   requests: NetworkRequest[];
+  flush?: boolean;
 }
 
 function methodColor(method: string): string {
@@ -131,7 +132,7 @@ function buildCurl(req: NetworkRequest): string {
 
 type DetailTab = "headers" | "request" | "response";
 
-export function NetworkLogContent({ requests }: NetworkLogContentProps) {
+export function NetworkLogContent({ requests, flush }: NetworkLogContentProps) {
   const t = useT();
   const [activeId, setActiveId] = useState<string | null>(null);
   const [detailTab, setDetailTab] = useState<DetailTab>("headers");
@@ -199,9 +200,9 @@ export function NetworkLogContent({ requests }: NetworkLogContentProps) {
   }, [listWidth]);
 
   return (
-    <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border">
+    <div ref={containerRef} className={`flex min-h-0 flex-1 flex-col overflow-hidden${flush ? "" : " rounded-lg border"}`}>
       <Tabs value={filter} onValueChange={(v) => setFilter(v as RequestFilter)}>
-        <div className="flex items-center gap-3 border-b p-2">
+        <div className={`flex items-center gap-3 border-b${flush ? " px-4 py-4" : " p-2"}`}>
           <TabsList>
             {availableFilters.map((f) => (
               <TabsTrigger key={f} value={f}>

--- a/src/sidepanel/tabs/ConsoleSubTab.tsx
+++ b/src/sidepanel/tabs/ConsoleSubTab.tsx
@@ -25,11 +25,10 @@ export function ConsoleSubTab({ active }: { active: boolean }) {
   }, [active]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col p-4">
-      <ConsoleLogContent
-        entries={consoleLog?.entries ?? []}
-        startedAt={consoleLog?.startedAt ?? Date.now()}
-      />
-    </div>
+    <ConsoleLogContent
+      flush
+      entries={consoleLog?.entries ?? []}
+      startedAt={consoleLog?.startedAt ?? Date.now()}
+    />
   );
 }

--- a/src/sidepanel/tabs/DraftDetailDialog.tsx
+++ b/src/sidepanel/tabs/DraftDetailDialog.tsx
@@ -643,7 +643,7 @@ export function DraftDetailDialog({
               </Card>
 
               {available.length === 0 ? (
-                <Alert variant="ghost">
+                <Alert variant="default">
                   <Info className="h-4 w-4" />
                   <AlertTitle>{t("platform.empty.title")}</AlertTitle>
                   <AlertDescription>{t("platform.empty.body")}</AlertDescription>

--- a/src/sidepanel/tabs/IssueCreateModal.tsx
+++ b/src/sidepanel/tabs/IssueCreateModal.tsx
@@ -11,7 +11,7 @@ import {
   SiLinear,
   SiNotion,
 } from "@icons-pack/react-simple-icons";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -92,8 +92,7 @@ import { extractNotionPageId } from "@/lib/notion-page-id";
 
 type SubmitState =
   | { status: "idle" }
-  | { status: "submitting" }
-  | { status: "error"; message: string };
+  | { status: "submitting" };
 
 export function IssueCreateModal() {
   const t = useT();
@@ -646,10 +645,8 @@ export function SubmitFieldsDialog(props: SubmitFieldsDialogProps) {
       onOpenChange(false);
       onSuccess?.(result);
     } catch (err) {
-      setSubmit({
-        status: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      toast.error(err instanceof Error ? err.message : String(err));
+      setSubmit({ status: "idle" });
     }
   }
 
@@ -723,12 +720,6 @@ export function SubmitFieldsDialog(props: SubmitFieldsDialogProps) {
             onChange={setNotionFields}
             onSchemaResolved={onNotionSchemaResolved}
           />
-        ) : null}
-
-        {submit.status === "error" ? (
-          <Alert variant="destructive" className="text-xs">
-            <AlertDescription>{submit.message}</AlertDescription>
-          </Alert>
         ) : null}
 
         <DialogFooter className="flex-row justify-end">

--- a/src/sidepanel/tabs/NetworkSubTab.tsx
+++ b/src/sidepanel/tabs/NetworkSubTab.tsx
@@ -25,8 +25,6 @@ export function NetworkSubTab({ active }: { active: boolean }) {
   }, [active]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col p-4">
-      <NetworkLogContent requests={networkLog?.requests ?? []} />
-    </div>
+    <NetworkLogContent flush requests={networkLog?.requests ?? []} />
   );
 }

--- a/src/sidepanel/tabs/PreviewPanel.tsx
+++ b/src/sidepanel/tabs/PreviewPanel.tsx
@@ -276,7 +276,7 @@ export function PreviewPanel() {
       </PageScroll>
       <PageFooter>
         {noPlatformConnected ? (
-          <Alert variant="ghost" className="mb-2">
+          <Alert variant="default" className="mb-2">
             <Info className="h-4 w-4" />
             <AlertTitle>{t("platform.empty.title")}</AlertTitle>
             <AlertDescription>{t("platform.empty.body")}</AlertDescription>

--- a/src/sidepanel/tabs/SettingsTab.tsx
+++ b/src/sidepanel/tabs/SettingsTab.tsx
@@ -1,10 +1,11 @@
 import { Fragment, useState } from "react";
-import { Bug, ListOrdered, Monitor, Moon, StickyNote, Sun, Target } from "lucide-react";
+import { Bug, ListOrdered, Monitor, Moon, SlidersHorizontal, Sparkles, StickyNote, Sun, Target } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useT } from "@/i18n";
 import {
@@ -38,9 +39,18 @@ export function SettingsTab() {
     >
       <div className="shrink-0 border-b border-border px-4 py-4">
         <TabsList className="grid h-9 w-full grid-cols-3">
-          <TabsTrigger value="issue">{t("settings.tab.issue")}</TabsTrigger>
-          <TabsTrigger value="ai">{t("settings.tab.ai")}</TabsTrigger>
-          <TabsTrigger value="general">{t("settings.tab.general")}</TabsTrigger>
+          <TabsTrigger value="issue" className="gap-1.5">
+            <StickyNote className="h-3.5 w-3.5" />
+            {t("settings.tab.issue")}
+          </TabsTrigger>
+          <TabsTrigger value="ai" className="gap-1.5">
+            <Sparkles className="h-3.5 w-3.5" />
+            {t("settings.tab.ai")}
+          </TabsTrigger>
+          <TabsTrigger value="general" className="gap-1.5">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            {t("settings.tab.general")}
+          </TabsTrigger>
         </TabsList>
       </div>
 
@@ -131,28 +141,36 @@ function GeneralSettingsContent() {
     <PageShell>
       <PageScroll>
         <Section title={t("settings.language")}>
-          <Tabs value={locale} onValueChange={(v) => setLocale(v as LocaleMode)}>
-            <TabsList className="grid w-full grid-cols-2">
+          <Select value={locale} onValueChange={(v) => setLocale(v as LocaleMode)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
               {LOCALE_OPTIONS.map((o) => (
-                <TabsTrigger key={o.value} value={o.value}>
+                <SelectItem key={o.value} value={o.value}>
                   {o.label}
-                </TabsTrigger>
+                </SelectItem>
               ))}
-            </TabsList>
-          </Tabs>
+            </SelectContent>
+          </Select>
         </Section>
 
         <Section title={t("settings.theme")}>
-          <Tabs value={theme} onValueChange={(v) => setTheme(v as ThemeMode)}>
-            <TabsList className="grid w-full grid-cols-3">
+          <Select value={theme} onValueChange={(v) => setTheme(v as ThemeMode)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
               {themeOptions.map((o) => (
-                <TabsTrigger key={o.value} value={o.value} className="gap-1.5">
-                  {o.icon}
-                  {o.label}
-                </TabsTrigger>
+                <SelectItem key={o.value} value={o.value}>
+                  <span className="inline-flex items-center gap-1.5">
+                    {o.icon}
+                    {o.label}
+                  </span>
+                </SelectItem>
               ))}
-            </TabsList>
-          </Tabs>
+            </SelectContent>
+          </Select>
         </Section>
       </PageScroll>
       <PageFooter>

--- a/src/sidepanel/tabs/connect/GithubConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/GithubConnectForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { CircleCheck, ExternalLink, KeyRound, Loader2 } from "lucide-react";
 import { SiGithub as Github } from "@icons-pack/react-simple-icons";
+import { toast } from "sonner";
 import { useT } from "@/i18n";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -104,7 +104,6 @@ function GithubOnboarding() {
   const t = useT();
   const [oauthAvailable, setOauthAvailable] = useState<boolean | null>(null);
   const [connecting, setConnecting] = useState(false);
-  const [oauthError, setOauthError] = useState<string | null>(null);
   const [patOpen, setPatOpen] = useState(false);
 
   const setAccount = useSettingsStore((s) => s.setAccount);
@@ -120,7 +119,6 @@ function GithubOnboarding() {
   }, []);
 
   async function startOAuth() {
-    setOauthError(null);
     setConnecting(true);
     try {
       const auth = await sendBg<GithubOAuthAuth>({ type: "github.startOAuth" });
@@ -133,7 +131,7 @@ function GithubOnboarding() {
       setAccount("github", next);
     } catch (err) {
       if (!isOAuthCancelled(err)) {
-        setOauthError(err instanceof Error ? err.message : String(err));
+        toast.error(err instanceof Error ? err.message : String(err));
       }
     } finally {
       setConnecting(false);
@@ -186,11 +184,6 @@ function GithubOnboarding() {
             {t("github.oauth.notConfigured")}
           </p>
         ) : null}
-        {oauthError ? (
-          <Alert variant="destructive" className="text-xs">
-            <AlertDescription>{oauthError}</AlertDescription>
-          </Alert>
-        ) : null}
       </div>
 
       <PatDialog open={patOpen} onOpenChange={setPatOpen} />
@@ -208,14 +201,12 @@ function PatDialog({
   const t = useT();
   const setAccount = useSettingsStore((s) => s.setAccount);
   const [pat, setPat] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [validating, setValidating] = useState(false);
 
   const trimmed = pat.trim();
   const canValidate = !!trimmed && !validating;
 
   async function handleValidate() {
-    setError(null);
     setValidating(true);
     try {
       const me = await sendBg<GithubMyself>({
@@ -237,7 +228,7 @@ function PatDialog({
       setPat("");
       onOpenChange(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       setValidating(false);
     }
@@ -279,11 +270,6 @@ function PatDialog({
             />
           </div>
 
-          {error ? (
-            <Alert variant="destructive" className="text-xs">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
         </div>
 
         <DialogFooter className="flex-row justify-end">

--- a/src/sidepanel/tabs/connect/JiraConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/JiraConnectForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { CircleCheck, ExternalLink, KeyRound, Loader2 } from "lucide-react";
 import { SiJirasoftware as Jira } from "@icons-pack/react-simple-icons";
+import { toast } from "sonner";
 import { useT } from "@/i18n";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -93,7 +93,6 @@ function JiraOnboarding() {
 
   const [oauthAvailable, setOauthAvailable] = useState<boolean | null>(null);
   const [connecting, setConnecting] = useState(false);
-  const [error, setError] = useState<OAuthClassified | null>(null);
   const [candidate, setCandidate] = useState<OAuthStartResultMsg | null>(null);
   const [apiKeyOpen, setApiKeyOpen] = useState(false);
 
@@ -107,8 +106,23 @@ function JiraOnboarding() {
     };
   }, []);
 
+  function showOAuthError(err: unknown) {
+    const classified = classifyOAuthClassified(err);
+    if (!classified) return;
+    if (classified.kind === "noJira") {
+      toast.error(t("jira.oauthError.noJira.title"), {
+        description: t("jira.oauthError.noJira.body"),
+        action: {
+          label: t("jira.switchAccount"),
+          onClick: () => window.open("https://id.atlassian.com/logout", "_blank"),
+        },
+      });
+    } else {
+      toast.error(classified.message);
+    }
+  }
+
   async function startOAuth() {
-    setError(null);
     setConnecting(true);
     try {
       const result = await sendBg<OAuthStartResultMsg>({ type: "oauth.start" });
@@ -121,14 +135,13 @@ function JiraOnboarding() {
         setCandidate(result);
       }
     } catch (err) {
-      setError(classifyOAuthClassified(err));
+      showOAuthError(err);
     } finally {
       setConnecting(false);
     }
   }
 
   async function finalize(result: OAuthStartResultMsg, site: JiraSite) {
-    setError(null);
     setConnecting(true);
     try {
       const auth: JiraOAuthAuth = {
@@ -152,7 +165,7 @@ function JiraOnboarding() {
       setAccount("jira", next);
       setCandidate(null);
     } catch (err) {
-      setError(classifyOAuthClassified(err));
+      showOAuthError(err);
     } finally {
       setConnecting(false);
     }
@@ -188,7 +201,6 @@ function JiraOnboarding() {
               </div>
             </Button>
           ))}
-          <OAuthClassifiedBanner error={error} />
         </div>
       </div>
     );
@@ -235,7 +247,6 @@ function JiraOnboarding() {
           </Button>
         </div>
 
-        <OAuthClassifiedBanner error={error} />
       </div>
 
       <ApiKeyDialog open={apiKeyOpen} onOpenChange={setApiKeyOpen} />
@@ -255,7 +266,6 @@ function ApiKeyDialog({
   const [baseUrl, setBaseUrl] = useState("");
   const [email, setEmail] = useState("");
   const [apiToken, setApiToken] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [validating, setValidating] = useState(false);
 
   const trimmed: JiraApiKeyAuth = {
@@ -268,7 +278,6 @@ function ApiKeyDialog({
     !!trimmed.baseUrl && !!trimmed.email && !!trimmed.apiToken && !validating;
 
   async function handleValidate() {
-    setError(null);
     setValidating(true);
     try {
       await sendBg<JiraMyself>({
@@ -283,7 +292,7 @@ function ApiKeyDialog({
       setAccount("jira", next);
       onOpenChange(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       setValidating(false);
     }
@@ -353,11 +362,6 @@ function ApiKeyDialog({
             />
           </div>
 
-          {error ? (
-            <Alert variant="destructive" className="text-xs">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
         </div>
 
         <DialogFooter className="flex-row justify-end">
@@ -377,41 +381,6 @@ function ApiKeyDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function OAuthClassifiedBanner({ error }: { error: OAuthClassified | null }) {
-  const t = useT();
-  if (!error) return null;
-  if (error.kind === "noJira") {
-    return (
-      <Alert variant="destructive" className="text-xs">
-        <div className="flex items-start justify-between gap-2">
-          <div>
-            <AlertTitle className="text-xs">
-              {t("jira.oauthError.noJira.title")}
-            </AlertTitle>
-            <AlertDescription className="text-xs text-destructive/80">
-              {t("jira.oauthError.noJira.body")}
-            </AlertDescription>
-          </div>
-          <a
-            href="https://id.atlassian.com/logout"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-0.5 inline-flex shrink-0 items-center gap-1 text-[11px] text-destructive/70 underline underline-offset-2 transition-colors hover:text-destructive"
-          >
-            {t("jira.switchAccount")}
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        </div>
-      </Alert>
-    );
-  }
-  return (
-    <Alert variant="destructive" className="text-xs">
-      <AlertDescription>{error.message}</AlertDescription>
-    </Alert>
   );
 }
 

--- a/src/sidepanel/tabs/connect/LinearConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/LinearConnectForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { CircleCheck, ExternalLink, KeyRound, Loader2 } from "lucide-react";
 import { SiLinear } from "@icons-pack/react-simple-icons";
+import { toast } from "sonner";
 import { useT } from "@/i18n";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -127,7 +127,6 @@ function LinearOnboarding() {
   const t = useT();
   const [oauthAvailable, setOauthAvailable] = useState<boolean | null>(null);
   const [connecting, setConnecting] = useState(false);
-  const [oauthError, setOauthError] = useState<string | null>(null);
   const [apiKeyOpen, setApiKeyOpen] = useState(false);
 
   const setAccount = useSettingsStore((s) => s.setAccount);
@@ -143,7 +142,6 @@ function LinearOnboarding() {
   }, []);
 
   async function startOAuth() {
-    setOauthError(null);
     setConnecting(true);
     try {
       const auth = await sendBg<LinearOAuthAuth>({ type: "linear.startOAuth" });
@@ -156,7 +154,7 @@ function LinearOnboarding() {
       setAccount("linear", next);
     } catch (err) {
       if (!isOAuthCancelled(err)) {
-        setOauthError(err instanceof Error ? err.message : String(err));
+        toast.error(err instanceof Error ? err.message : String(err));
       }
     } finally {
       setConnecting(false);
@@ -209,11 +207,6 @@ function LinearOnboarding() {
             {t("linear.oauth.notConfigured")}
           </p>
         ) : null}
-        {oauthError ? (
-          <Alert variant="destructive" className="mt-3 text-xs">
-            <AlertDescription>{oauthError}</AlertDescription>
-          </Alert>
-        ) : null}
       </div>
 
       <ApiKeyDialog open={apiKeyOpen} onOpenChange={setApiKeyOpen} />
@@ -231,14 +224,12 @@ function ApiKeyDialog({
   const t = useT();
   const setAccount = useSettingsStore((s) => s.setAccount);
   const [apiKey, setApiKey] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [validating, setValidating] = useState(false);
 
   const trimmed = apiKey.trim();
   const canValidate = !!trimmed && !validating;
 
   async function handleValidate() {
-    setError(null);
     setValidating(true);
     try {
       const me = await sendBg<LinearMyself>({
@@ -260,7 +251,7 @@ function ApiKeyDialog({
       setApiKey("");
       onOpenChange(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       setValidating(false);
     }
@@ -302,11 +293,6 @@ function ApiKeyDialog({
             />
           </div>
 
-          {error ? (
-            <Alert variant="destructive" className="text-xs">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
         </div>
 
         <DialogFooter className="flex-row justify-end">

--- a/src/sidepanel/tabs/connect/NotionConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/NotionConnectForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { CircleCheck, ExternalLink, KeyRound, Loader2 } from "lucide-react";
 import { SiNotion } from "@icons-pack/react-simple-icons";
+import { toast } from "sonner";
 import { useT } from "@/i18n";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -182,7 +182,6 @@ function NotionOnboarding() {
   const t = useT();
   const [oauthAvailable, setOauthAvailable] = useState<boolean | null>(null);
   const [connecting, setConnecting] = useState(false);
-  const [oauthError, setOauthError] = useState<string | null>(null);
   const [tokenOpen, setTokenOpen] = useState(false);
 
   const setAccount = useSettingsStore((s) => s.setAccount);
@@ -198,7 +197,6 @@ function NotionOnboarding() {
   }, []);
 
   async function startOAuth() {
-    setOauthError(null);
     setConnecting(true);
     try {
       const auth = await sendBg<NotionOAuthAuth>({ type: "notion.startOAuth" });
@@ -211,7 +209,7 @@ function NotionOnboarding() {
       setAccount("notion", next);
     } catch (err) {
       if (!isOAuthCancelled(err)) {
-        setOauthError(err instanceof Error ? err.message : String(err));
+        toast.error(err instanceof Error ? err.message : String(err));
       }
     } finally {
       setConnecting(false);
@@ -264,11 +262,6 @@ function NotionOnboarding() {
             {t("notion.oauth.notConfigured")}
           </p>
         ) : null}
-        {oauthError ? (
-          <Alert variant="destructive" className="mt-3 text-xs">
-            <AlertDescription>{oauthError}</AlertDescription>
-          </Alert>
-        ) : null}
       </div>
 
       <InternalTokenDialog open={tokenOpen} onOpenChange={setTokenOpen} />
@@ -286,14 +279,12 @@ function InternalTokenDialog({
   const t = useT();
   const setAccount = useSettingsStore((s) => s.setAccount);
   const [token, setToken] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [validating, setValidating] = useState(false);
 
   const trimmed = token.trim();
   const canValidate = !!trimmed && !validating;
 
   async function handleValidate() {
-    setError(null);
     setValidating(true);
     try {
       const me = await sendBg<NotionMyself>({
@@ -315,7 +306,7 @@ function InternalTokenDialog({
       setToken("");
       onOpenChange(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      toast.error(err instanceof Error ? err.message : String(err));
     } finally {
       setValidating(false);
     }
@@ -365,11 +356,6 @@ function InternalTokenDialog({
             </p>
           </div>
 
-          {error ? (
-            <Alert variant="destructive" className="text-xs">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
         </div>
 
         <DialogFooter className="flex-row justify-end">

--- a/src/sidepanel/tabs/settings/LlmConnectDialog.tsx
+++ b/src/sidepanel/tabs/settings/LlmConnectDialog.tsx
@@ -6,8 +6,8 @@ import {
   SiOllama,
   SiOpenrouter,
 } from "@icons-pack/react-simple-icons";
+import { toast } from "sonner";
 import { useT } from "@/i18n";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -101,7 +101,6 @@ export function LlmConnectDialog({
   const [baseUrl, setBaseUrl] = useState("");
   const [search, setSearch] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [pendingModels, setPendingModels] = useState<{
@@ -112,7 +111,6 @@ export function LlmConnectDialog({
 
   useEffect(() => {
     if (open) {
-      setError(null);
       cancelledRef.current = false;
     }
     return () => { cancelledRef.current = true; };
@@ -140,11 +138,10 @@ export function LlmConnectDialog({
   }
 
   async function handleConnect() {
-    setError(null);
     try {
       new URL(baseUrl);
     } catch {
-      setError(t("llm.error.invalidUrl"));
+      toast.error(t("llm.error.invalidUrl"));
       return;
     }
     setConnecting(true);
@@ -152,7 +149,7 @@ export function LlmConnectDialog({
       const granted = await requestHostPermission(baseUrl);
       if (cancelledRef.current) return;
       if (!granted) {
-        setError(t("llm.error.permission"));
+        toast.error(t("llm.error.permission"));
         return;
       }
 
@@ -176,7 +173,7 @@ export function LlmConnectDialog({
       setPendingModels({ models, baseUrl });
     } catch {
       if (cancelledRef.current) return;
-      setError(t("llm.error.fetch"));
+      toast.error(t("llm.error.fetch"));
     } finally {
       if (!cancelledRef.current) setConnecting(false);
     }
@@ -295,11 +292,6 @@ export function LlmConnectDialog({
             </div>
           </div>
 
-          {error ? (
-            <Alert variant="destructive" className="text-xs">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          ) : null}
         </div>
 
         <DialogFooter className="flex-row justify-end">


### PR DESCRIPTION
## Summary

- **Toggle/Tab styling**: unselected text-muted-foreground with hover text-foreground; segment variant bg-muted/bg-background matching TabsList pattern
- **Main tab unification**: replace ToggleGroup (segment variant) with standard Tabs component for consistent UI across all tab levels
- **Settings sub-tabs**: add icons (StickyNote/Sparkles/SlidersHorizontal), replace language/theme Tabs with Select, rename "기타" to "일반"
- **TabsTrigger**: add hover:text-foreground transition
- **Prior releases included**: v1.1.4 (Debug tab + background log capture) and v1.1.5 (GitHub inline upload fix, mp4 recording, issue list UX)

## Test plan

- [ ] Main tabs render with correct selected/unselected styling (bg-background vs bg-muted)
- [ ] Settings sub-tabs show icons and correct labels
- [ ] Language/theme selectors work as Select dropdowns
- [ ] Debug, Integrations sub-tabs render correctly
- [ ] Dark mode styling consistent across all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)