### PR TITLE
v1.1.8 — AI prompt reliability, i18n polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ pnpm version major --no-git-tag-version   # 1.0.0 → 2.0.0 (Breaking change)
 /pull           → dev 최신 받고 작업 맥락 브리핑
 /build          → pnpm build + 테스트 체크리스트 (작업 중 검증)
 /code-review    → origin/main 대비 변경 코드 시급도별 리포트 (리포트 전용, fix·빌드·커밋 안 함)
+/audit          → 코드베이스 전체 컨벤션·패턴 감사 (리포트 전용, fix·빌드·커밋 안 함)
 /push           → dev push (main에서 호출 차단)
 /merge          → dev에서 버전 bump 커밋 + dev → main squash PR 생성 + 자동 머지
 /deploy         → main 한정. tag push → 스토어 빌드 → zip → GitHub Release draft → 심사 요청 안내

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.1.7",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background/oauth.ts
+++ b/src/background/oauth.ts
@@ -1,6 +1,7 @@
 import { t } from "@/i18n";
 import type { JiraOAuthAuth, JiraSite } from "@/types/jira";
 import type { PlatformId } from "@/types/platform";
+import { writeStoredOAuthTokens } from "@/lib/settings-storage";
 
 const CLIENT_ID = import.meta.env.VITE_ATLASSIAN_CLIENT_ID ?? "";
 const PROXY_URL = (import.meta.env.VITE_OAUTH_PROXY_URL ?? "").replace(
@@ -193,8 +194,6 @@ export async function refreshOAuthToken(
     expiresAt: Date.now() + data.expires_in * 1000,
   };
 }
-
-import { writeStoredOAuthTokens } from "@/lib/settings-storage";
 
 export async function persistOAuthTokens(auth: JiraOAuthAuth): Promise<void> {
   try {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -91,6 +91,17 @@ const en = {
   "editor.revertClass": "Revert to original classes",
   "editor.revertSection": "Revert inline for this section",
 
+  // Style editor sections
+  "editor.section.class": "Class",
+  "editor.section.layout": "Layout",
+  "editor.section.container": "Container",
+  "editor.section.size": "Size",
+  "editor.section.overflow": "Overflow",
+  "editor.section.text": "Text",
+  "editor.section.typography": "Typography",
+  "editor.section.effects": "Effects",
+  "editor.section.transition": "Transition",
+
   // Style prop editors
   "prop.editIndividual": "Edit individually",
   "prop.editTogether": "Edit together",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -89,6 +89,17 @@ const ko = {
   "editor.revertClass": "원본 class로 되돌리기",
   "editor.revertSection": "이 섹션 인라인 원복",
 
+  // Style editor sections
+  "editor.section.class": "Class",
+  "editor.section.layout": "Layout",
+  "editor.section.container": "Container",
+  "editor.section.size": "Size",
+  "editor.section.overflow": "Overflow",
+  "editor.section.text": "Text",
+  "editor.section.typography": "Typography",
+  "editor.section.effects": "Effects",
+  "editor.section.transition": "Transition",
+
   // Style prop editors
   "prop.editIndividual": "개별 편집",
   "prop.editTogether": "일괄 편집",

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -25,9 +25,6 @@ import {
   onVideoRecordingUnavailable,
 } from "@/types/messages";
 import { PLATFORM_TAB_KEYS, type PlatformId } from "@/types/platform";
-
-const TabNavContext = createContext<(tab: string) => void>(() => {});
-export const useTabNav = () => useContext(TabNavContext);
 import { useBoundTabId } from "./hooks/useBoundTabId";
 import { useEditorSessionSync } from "./hooks/useEditorSessionSync";
 import { useBackgroundRecorder } from "./hooks/useBackgroundRecorder";
@@ -37,6 +34,9 @@ import { DebugTab } from "./tabs/DebugTab";
 import { IntegrationsTab } from "./tabs/IntegrationsTab";
 import { IssueListTab } from "./tabs/IssueListTab";
 import { SettingsTab } from "./tabs/SettingsTab";
+
+const TabNavContext = createContext<(tab: string) => void>(() => {});
+export const useTabNav = () => useContext(TabNavContext);
 
 function useSettingsHydrated() {
   const [ready, setReady] = useState(

--- a/src/sidepanel/lib/__tests__/buildAiDraftPrompt.test.ts
+++ b/src/sidepanel/lib/__tests__/buildAiDraftPrompt.test.ts
@@ -69,6 +69,32 @@ describe("buildAiDraftPrompt", () => {
     expect(prompt).not.toContain('color: "red"');
   });
 
+  it("element 모드: 섹션 설명에 current/desired 힌트 포함", () => {
+    const prompt = buildAiDraftPrompt({ ...BASE_CTX, captureMode: "element" });
+    expect(prompt).toContain("current");
+    expect(prompt).toContain("desired");
+  });
+
+  it("screenshot 모드: 섹션 설명에 current/desired 힌트 없음, 스크린샷 힌트 포함", () => {
+    const prompt = buildAiDraftPrompt({
+      ...BASE_CTX,
+      captureMode: "screenshot",
+    });
+    expect(prompt).not.toMatch(/current value|current 값/);
+    expect(prompt).not.toMatch(/desired value|desired 값/);
+    expect(prompt).toMatch(/screenshot|스크린샷/i);
+  });
+
+  it("video 모드: 섹션 설명에 current/desired 힌트 없음, 에러 로그 힌트 포함", () => {
+    const prompt = buildAiDraftPrompt({
+      ...BASE_CTX,
+      captureMode: "video",
+    });
+    expect(prompt).not.toMatch(/current value|current 값/);
+    expect(prompt).not.toMatch(/desired value|desired 값/);
+    expect(prompt).toMatch(/error log|에러 로그/i);
+  });
+
   it("locale ko → Korean, en → English", () => {
     const koPrompt = buildAiDraftPrompt({ ...BASE_CTX, locale: "ko" });
     expect(koPrompt).toContain("Korean");
@@ -317,5 +343,22 @@ describe("buildAiDraftSessionPrompt", () => {
       captureMode: "video",
     });
     expect(prompt).not.toMatch(/image|이미지/i);
+  });
+
+  it("screenshot 모드: 섹션 설명에 current/desired 힌트 없음", () => {
+    const prompt = buildAiDraftSessionPrompt(SESSION_BASE);
+    expect(prompt).not.toMatch(/current value|current 값/);
+    expect(prompt).not.toMatch(/desired value|desired 값/);
+    expect(prompt).toMatch(/screenshot|스크린샷/i);
+  });
+
+  it("video 모드: 섹션 설명에 current/desired 힌트 없음, 녹화 맥락 포함", () => {
+    const prompt = buildAiDraftSessionPrompt({
+      ...SESSION_BASE,
+      captureMode: "video",
+    });
+    expect(prompt).not.toMatch(/current value|current 값/);
+    expect(prompt).not.toMatch(/desired value|desired 값/);
+    expect(prompt).toMatch(/record|녹화/i);
   });
 });

--- a/src/sidepanel/lib/__tests__/buildAiStylingPrompt.test.ts
+++ b/src/sidepanel/lib/__tests__/buildAiStylingPrompt.test.ts
@@ -3,6 +3,7 @@ import {
   buildAiStylingSystemPrompt,
   buildAiStylingResponseSchema,
   parseAiStylingResponse,
+  buildStyleContextBlock,
   type AiStylingContext,
 } from "../buildAiStylingPrompt";
 import { mergeAiEdits, replaceRawWithTokens } from "../aiStylingPostProcess";
@@ -79,6 +80,46 @@ describe("buildAiStylingSystemPrompt", () => {
     expect(prompt).not.toContain("Design tokens");
   });
 
+  it("금지 속성 목록 포함", () => {
+    const prompt = buildAiStylingSystemPrompt(BASE_CTX);
+    expect(prompt).toContain("content");
+    expect(prompt).toContain("animation");
+    expect(prompt).toContain("will-change");
+  });
+});
+
+describe("buildStyleContextBlock", () => {
+  it("현재 스타일과 클래스를 블록으로 직렬화", () => {
+    const block = buildStyleContextBlock({
+      ...BASE_CTX,
+      specifiedStyles: { "font-size": "14px", color: "#333" },
+      classList: ["btn", "primary"],
+    });
+    expect(block).toContain("[Current state]");
+    expect(block).toContain("font-size: 14px");
+    expect(block).toContain("color: #333");
+    expect(block).toContain("Classes: btn primary");
+  });
+
+  it("스타일 비어있으면 스타일 라인 생략", () => {
+    const block = buildStyleContextBlock({
+      ...BASE_CTX,
+      specifiedStyles: {},
+      classList: ["btn"],
+    });
+    expect(block).toContain("[Current state]");
+    expect(block).not.toContain("font-size");
+    expect(block).toContain("Classes: btn");
+  });
+
+  it("클래스 비어있으면 (none)", () => {
+    const block = buildStyleContextBlock({
+      ...BASE_CTX,
+      specifiedStyles: { color: "red" },
+      classList: [],
+    });
+    expect(block).toContain("Classes: (none)");
+  });
 });
 
 describe("buildAiStylingResponseSchema", () => {
@@ -112,12 +153,15 @@ describe("parseAiStylingResponse", () => {
     expect(result?.edits.inlineStyle).toEqual({ color: "red" });
   });
 
-  it("허용되지 않는 CSS 속성 필터링", () => {
+  it("deny-list 속성 필터링 (animation-name, content 등)", () => {
     const raw = JSON.stringify({
       explanation: "Styled",
       inlineStyle: {
         color: "red",
         "animation-name": "spin",
+        content: '"hello"',
+        "will-change": "transform",
+        "counter-increment": "section",
         "font-size": "16px",
       },
     });
@@ -126,10 +170,71 @@ describe("parseAiStylingResponse", () => {
       color: "red",
       "font-size": "16px",
     });
-    expect(result?.edits.inlineStyle).not.toHaveProperty("animation-name");
   });
 
-  it("새로 추가된 속성 허용 (z-index, transform 등)", () => {
+  it("기존 allowlist에 없던 속성도 통과 (font-family, text-decoration 등)", () => {
+    const raw = JSON.stringify({
+      explanation: "Styled",
+      inlineStyle: {
+        "font-family": "Arial, sans-serif",
+        "text-decoration": "underline",
+        "grid-template-columns": "1fr 1fr",
+        "flex-grow": "1",
+        "border-width": "2px",
+        "border-style": "solid",
+        outline: "none",
+        "word-break": "break-all",
+        "box-sizing": "border-box",
+        "list-style": "none",
+        "align-self": "center",
+        "text-transform": "uppercase",
+      },
+    });
+    const result = parseAiStylingResponse(raw);
+    expect(result?.edits.inlineStyle).toEqual({
+      "font-family": "Arial, sans-serif",
+      "text-decoration": "underline",
+      "grid-template-columns": "1fr 1fr",
+      "flex-grow": "1",
+      "border-width": "2px",
+      "border-style": "solid",
+      outline: "none",
+      "word-break": "break-all",
+      "box-sizing": "border-box",
+      "list-style": "none",
+      "align-self": "center",
+      "text-transform": "uppercase",
+    });
+  });
+
+  it("커스텀 속성(--*) 필터링", () => {
+    const raw = JSON.stringify({
+      explanation: "Token set",
+      inlineStyle: {
+        color: "red",
+        "--my-custom-color": "blue",
+        "--spacing": "8px",
+      },
+    });
+    const result = parseAiStylingResponse(raw);
+    expect(result?.edits.inlineStyle).toEqual({ color: "red" });
+  });
+
+  it("animation shorthand도 필터링", () => {
+    const raw = JSON.stringify({
+      explanation: "Animated",
+      inlineStyle: {
+        animation: "spin 1s infinite",
+        "animation-duration": "2s",
+        "animation-delay": "0.5s",
+        opacity: "0.5",
+      },
+    });
+    const result = parseAiStylingResponse(raw);
+    expect(result?.edits.inlineStyle).toEqual({ opacity: "0.5" });
+  });
+
+  it("z-index, transform 등 통과", () => {
     const raw = JSON.stringify({
       explanation: "Positioned",
       inlineStyle: {
@@ -233,7 +338,7 @@ describe("parseAiStylingResponse", () => {
     });
   });
 
-  it("camelCase 허용 안 되는 속성은 변환 후에도 필터링", () => {
+  it("camelCase deny-list 속성은 변환 후에도 필터링", () => {
     const raw = JSON.stringify({
       explanation: "ok",
       inlineStyle: { animationName: "spin", color: "blue" },

--- a/src/sidepanel/lib/ai-provider.ts
+++ b/src/sidepanel/lib/ai-provider.ts
@@ -268,7 +268,7 @@ export function createAnthropicProvider(config: LlmConfig): AIProvider {
   return {
     async generate({ systemPrompt, prompt, images, responseSchema }) {
       const sys = responseSchema
-        ? `${systemPrompt ?? ""}\n\nRespond with valid JSON only.`
+        ? `${systemPrompt ?? ""}\n\nRespond with valid JSON only. Schema: ${JSON.stringify(responseSchema)}`
         : (systemPrompt ?? "");
       return callMessages(sys, [{ role: "user", content: buildAnthropicContent(prompt, images) }]);
     },
@@ -277,7 +277,7 @@ export function createAnthropicProvider(config: LlmConfig): AIProvider {
       return {
         async prompt(input, options) {
           const sys = options?.responseSchema
-            ? `${systemPrompt}\n\nRespond with valid JSON only.`
+            ? `${systemPrompt}\n\nRespond with valid JSON only. Schema: ${JSON.stringify(options.responseSchema)}`
             : systemPrompt;
           messages.push({ role: "user", content: buildAnthropicContent(input, options?.images) });
           const result = await callMessages(sys, messages);

--- a/src/sidepanel/lib/buildAiDraftPrompt.ts
+++ b/src/sidepanel/lib/buildAiDraftPrompt.ts
@@ -26,20 +26,47 @@ export interface AiDraftContext {
   enabledSections: { id: IssueSectionId; renderAs: IssueSectionRenderAs }[];
 }
 
-const SECTION_DESC: Record<LocaleMode, Record<IssueSectionId, string>> = {
+const SECTION_DESC_BASE: Record<LocaleMode, Record<IssueSectionId, string>> = {
   ko: {
-    description: "발생 현상을 구체적으로 설명 (current 값이 현재 문제 상태)",
+    description: "발생 현상을 구체적으로 설명",
     stepsToReproduce: "재현 과정을 줄바꿈으로 구분된 단계로 작성 (번호 없이)",
-    expectedResult: "수정 후 기대되는 동작 (desired 값 기준으로 작성)",
+    expectedResult: "수정 후 기대되는 동작",
     notes: "추가 참고 사항. 없으면 빈 문자열",
   },
   en: {
-    description: "describe the issue in detail (current value is the problem)",
+    description: "describe the issue in detail",
     stepsToReproduce: "write reproduction steps as newline-separated lines (no numbering)",
-    expectedResult: "expected behavior after fix (use the desired value)",
+    expectedResult: "expected behavior after fix",
     notes: "additional notes. Leave empty string if nothing to add",
   },
 };
+
+const MODE_HINTS: Record<CaptureMode, Record<LocaleMode, Partial<Record<IssueSectionId, string>>>> = {
+  element: {
+    ko: { description: " (current 값이 현재 문제 상태)", expectedResult: " (desired 값 기준으로 작성)" },
+    en: { description: " (current value is the problem)", expectedResult: " (use the desired value)" },
+  },
+  screenshot: {
+    ko: { description: " (스크린샷과 사용자 설명 기반)" },
+    en: { description: " (based on the screenshot and user description)" },
+  },
+  video: {
+    ko: { description: " (사용자 설명과 에러 로그 기반)" },
+    en: { description: " (based on user description and error logs)" },
+  },
+};
+
+function getSectionDesc(
+  locale: LocaleMode,
+  mode: CaptureMode,
+): Record<IssueSectionId, string> {
+  const base = { ...SECTION_DESC_BASE[locale] };
+  const hints = MODE_HINTS[mode]?.[locale] ?? {};
+  for (const [key, suffix] of Object.entries(hints)) {
+    base[key as IssueSectionId] += suffix;
+  }
+  return base;
+}
 
 export function buildAiDraftPrompt(ctx: AiDraftContext): string {
   const lang = ctx.locale === "ko" ? "Korean" : "English";
@@ -87,7 +114,7 @@ export function buildAiDraftPrompt(ctx: AiDraftContext): string {
     }
   }
 
-  const desc = SECTION_DESC[ctx.locale];
+  const desc = getSectionDesc(ctx.locale, ctx.captureMode);
   lines.push("");
   lines.push("Output a JSON object with these exact keys:");
   lines.push('- "title": one short line, as brief as possible');
@@ -186,6 +213,7 @@ export function buildAiDraftSessionPrompt(ctx: AiDraftSessionContext): string {
   }
 
   if (ctx.captureMode === "video") {
+    lines.push("- The user recorded a screen video of the bug. They will describe what happened.");
     if (ctx.networkLogSummary && ctx.networkLogSummary.errors.length > 0) {
       lines.push("- Network errors:");
       for (const e of ctx.networkLogSummary.errors) {
@@ -203,7 +231,7 @@ export function buildAiDraftSessionPrompt(ctx: AiDraftSessionContext): string {
     }
   }
 
-  const desc = SECTION_DESC[ctx.locale];
+  const desc = getSectionDesc(ctx.locale, ctx.captureMode);
   lines.push("");
   lines.push("Output a JSON object with these exact keys:");
   lines.push('- "title": one short line, as brief as possible');

--- a/src/sidepanel/lib/buildAiStylingPrompt.ts
+++ b/src/sidepanel/lib/buildAiStylingPrompt.ts
@@ -16,70 +16,21 @@ export interface AiStylingContext {
 const MAX_STYLES = 30;
 const MAX_TOKENS = 20;
 
-const ALLOWED_STYLE_PROPS = new Set([
-  "display",
-  "position",
-  "flex-direction",
-  "flex-wrap",
-  "justify-content",
-  "align-items",
-  "margin",
-  "margin-top",
-  "margin-right",
-  "margin-bottom",
-  "margin-left",
-  "padding",
-  "padding-top",
-  "padding-right",
-  "padding-bottom",
-  "padding-left",
-  "gap",
-  "row-gap",
-  "column-gap",
-  "width",
-  "height",
-  "min-width",
-  "max-width",
-  "min-height",
-  "max-height",
-  "overflow",
-  "overflow-x",
-  "overflow-y",
-  "white-space",
-  "text-overflow",
-  "font-size",
-  "font-weight",
-  "line-height",
-  "letter-spacing",
-  "text-align",
-  "color",
-  "background-color",
-  "background-image",
-  "opacity",
-  "border",
-  "border-color",
-  "border-radius",
-  "border-top-left-radius",
-  "border-top-right-radius",
-  "border-bottom-right-radius",
-  "border-bottom-left-radius",
-  "box-shadow",
-  "filter",
-  "backdrop-filter",
-  "mix-blend-mode",
-  "transform",
-  "top",
-  "right",
-  "bottom",
-  "left",
-  "z-index",
-  "cursor",
-  "pointer-events",
-  "visibility",
-  "transition-property",
-  "transition-duration",
-  "transition-timing-function",
-  "transition-delay",
+const DENIED_STYLE_PROPS = new Set([
+  "content",
+  "animation",
+  "animation-name",
+  "animation-duration",
+  "animation-delay",
+  "animation-direction",
+  "animation-fill-mode",
+  "animation-iteration-count",
+  "animation-play-state",
+  "animation-timing-function",
+  "will-change",
+  "counter-increment",
+  "counter-reset",
+  "counter-set",
 ]);
 
 export function buildAiStylingSystemPrompt(ctx: AiStylingContext): string {
@@ -118,6 +69,7 @@ export function buildAiStylingSystemPrompt(ctx: AiStylingContext): string {
     "- inlineStyle: CSS property-value pairs in kebab-case",
     "- Prefer design tokens over raw values. When a matching token exists, use var(--token-name). Prioritize tokens from the same family already used on this element",
     "- classList: optional, the COMPLETE class list. Keep all existing classes, only add/remove what the user asked for",
+    "- Do NOT use these properties (they will be ignored): content, animation, animation-*, will-change, counter-*, custom properties (--*)",
     "- Do NOT include any other fields",
     "- Output only valid JSON, no markdown fences",
   );
@@ -163,7 +115,7 @@ export function parseAiStylingResponse(raw: string): {
     )) {
       if (typeof val !== "string" || !val) continue;
       const prop = toKebab(rawProp);
-      if (ALLOWED_STYLE_PROPS.has(prop)) {
+      if (!DENIED_STYLE_PROPS.has(prop) && !prop.startsWith("--")) {
         filtered[prop] = val;
       }
     }
@@ -178,6 +130,16 @@ export function parseAiStylingResponse(raw: string): {
   }
 
   return { explanation: parsed.explanation, edits };
+}
+
+export function buildStyleContextBlock(ctx: AiStylingContext): string {
+  const lines: string[] = ["[Current state]"];
+  const entries = Object.entries(ctx.specifiedStyles).slice(0, MAX_STYLES);
+  for (const [prop, val] of entries) {
+    lines.push(`  ${prop}: ${val}`);
+  }
+  lines.push(`Classes: ${ctx.classList.join(" ") || "(none)"}`);
+  return lines.join("\n");
 }
 
 function toKebab(s: string): string {

--- a/src/sidepanel/tabs/IntegrationsTab.tsx
+++ b/src/sidepanel/tabs/IntegrationsTab.tsx
@@ -6,6 +6,7 @@ import {
   SiNotion,
 } from "@icons-pack/react-simple-icons";
 import { useT } from "@/i18n";
+import type { TranslationKey } from "@/i18n/ko";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -31,7 +32,7 @@ type PlatformSubTab = "jira" | "github" | "linear" | "notion";
 
 const PLATFORM_ORDER: PlatformSubTab[] = ["jira", "github", "linear", "notion"];
 
-const PLATFORM_LABEL_KEYS: Record<PlatformSubTab, string> = {
+const PLATFORM_LABEL_KEYS: Record<PlatformSubTab, TranslationKey> = {
   jira: "platform.tab.jira",
   github: "platform.tab.github",
   linear: "platform.tab.linear",
@@ -132,12 +133,12 @@ export function IntegrationsTab() {
             <AlertDialog>
               <AlertDialogTrigger asChild>
                 <Button variant="outline">
-                  {t("platform.disconnectPlatform", { platform: t(PLATFORM_LABEL_KEYS[sub] as any) })}
+                  {t("platform.disconnectPlatform", { platform: t(PLATFORM_LABEL_KEYS[sub]) })}
                 </Button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>{t("platform.disconnect.title", { platform: t(PLATFORM_LABEL_KEYS[sub] as any) })}</AlertDialogTitle>
+                  <AlertDialogTitle>{t("platform.disconnect.title", { platform: t(PLATFORM_LABEL_KEYS[sub]) })}</AlertDialogTitle>
                   <AlertDialogDescription>{t("platform.disconnect.body")}</AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/src/sidepanel/tabs/StyleEditorPanel.tsx
+++ b/src/sidepanel/tabs/StyleEditorPanel.tsx
@@ -154,12 +154,12 @@ export function SelectedPanel() {
           </div>
         </div>
 
-        <Section title="Class" action={<ClassRevertButton />}>
+        <Section title={t("editor.section.class")} action={<ClassRevertButton />}>
           <ClassEditor />
         </Section>
 
         <Section
-          title="Layout"
+          title={t("editor.section.layout")}
           action={<SectionRevertButton props={SECTION_PROPS.layout} />}
           collapsible
           defaultOpen={hasSpecified(SECTION_PROPS.layout)}
@@ -224,7 +224,7 @@ export function SelectedPanel() {
       </Section>
 
       <Section
-        title="Container"
+        title={t("editor.section.container")}
         action={<SectionRevertButton props={SECTION_PROPS.container} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.container)}
@@ -242,7 +242,7 @@ export function SelectedPanel() {
       </Section>
 
       <Section
-        title="Size"
+        title={t("editor.section.size")}
         action={<SectionRevertButton props={SECTION_PROPS.size} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.size)}
@@ -262,7 +262,7 @@ export function SelectedPanel() {
       </Section>
 
       <Section
-        title="Overflow"
+        title={t("editor.section.overflow")}
         action={<SectionRevertButton props={SECTION_PROPS.overflow} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.overflow)}
@@ -307,13 +307,13 @@ export function SelectedPanel() {
       </Section>
 
       {selection.text !== null ? (
-        <Section title="Text" action={<TextRevertButton />}>
+        <Section title={t("editor.section.text")} action={<TextRevertButton />}>
           <TextEditor />
         </Section>
       ) : null}
 
       <Section
-        title="Typography"
+        title={t("editor.section.typography")}
         action={<SectionRevertButton props={SECTION_PROPS.typography} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.typography)}
@@ -334,7 +334,7 @@ export function SelectedPanel() {
 
 
       <Section
-        title="Effects"
+        title={t("editor.section.effects")}
         action={<SectionRevertButton props={SECTION_PROPS.effects} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.effects)}
@@ -366,7 +366,7 @@ export function SelectedPanel() {
         </Section>
 
       <Section
-        title="Transition"
+        title={t("editor.section.transition")}
         action={<SectionRevertButton props={SECTION_PROPS.transition} />}
         collapsible
         defaultOpen={hasSpecified(SECTION_PROPS.transition)}

--- a/src/sidepanel/tabs/styleEditor/AiStylingDialog.tsx
+++ b/src/sidepanel/tabs/styleEditor/AiStylingDialog.tsx
@@ -20,6 +20,7 @@ import {
   buildAiStylingSystemPrompt,
   buildAiStylingResponseSchema,
   parseAiStylingResponse,
+  buildStyleContextBlock,
   type AiStylingContext,
 } from "../../lib/buildAiStylingPrompt";
 import { mergeAiEdits, replaceRawWithTokens } from "../../lib/aiStylingPostProcess";
@@ -77,9 +78,12 @@ export function AiStylingDialog({
         );
       }
 
-      const raw = await sessionRef.current.prompt(msg, {
-        responseSchema: buildAiStylingResponseSchema(),
-      });
+      const ctx = buildContext();
+      const prefix = ctx ? buildStyleContextBlock(ctx) : "";
+      const raw = await sessionRef.current.prompt(
+        prefix ? `${prefix}\n\n${msg}` : msg,
+        { responseSchema: buildAiStylingResponseSchema() },
+      );
 
       const parsed = parseAiStylingResponse(raw);
       if (!parsed) {


### PR DESCRIPTION
## Summary
- **AI styling prompt**: switch CSS property allowlist (64) to deny-list (14) — fixes silent property drops causing "no change" after AI suggestions; add per-turn context refresh for multi-turn sessions; add denied properties to system prompt
- **AI draft prompt**: split section descriptions by capture mode (element/screenshot/video) so models get mode-appropriate hints instead of element-only "current/desired" references; add video recording context
- **Anthropic provider**: include JSON schema in system prompt for better structured output
- **UI polish**: i18n style editor section titles, import reorder, type safety fixes

## Test plan
- [x] `pnpm test` — 82 tests pass (53 styling + 29 draft)
- [x] `pnpm typecheck` — clean
- [ ] Manual: select element → AI styling → request `font-family`, `text-decoration`, `grid-template-columns` (previously silently dropped)
- [ ] Manual: screenshot/video mode → AI draft → verify section descriptions match capture mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)