### PR TITLE
Rename log tab freeform button and fix inline image bugs

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -70,6 +70,7 @@ const en = {
   "issue.mode.screenshot": "Screenshot",
   "issue.mode.video": "Record video",
   "issue.mode.freeform": "Freeform",
+  "issue.startDraft": "Write issue",
   "issue.picking.title": "Select an element",
   "issue.capturing.title": "Select capture area",
   "issue.recording.title": "Recording {time}",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -68,6 +68,7 @@ const ko = {
   "issue.mode.screenshot": "화면 캡처",
   "issue.mode.video": "영상 녹화",
   "issue.mode.freeform": "자유 작성",
+  "issue.startDraft": "이슈 작성",
   "issue.picking.title": "요소를 선택하세요",
   "issue.capturing.title": "캡처 영역을 선택하세요",
   "issue.recording.title": "녹화 중 {time}",

--- a/src/sidepanel/tabs/ConsoleSubTab.tsx
+++ b/src/sidepanel/tabs/ConsoleSubTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { PenLine } from "lucide-react";
+import { SquarePen } from "lucide-react";
 import { useT } from "@/i18n";
 import { Button } from "@/components/ui/button";
 import { useEditorStore } from "@/store/editor-store";
@@ -39,8 +39,8 @@ export function ConsoleSubTab({ active, onStartFreeform }: { active: boolean; on
       <PageFooter>
         <div className="flex justify-end">
           <Button variant="outline" onClick={onStartFreeform}>
-            <PenLine />
-            {t("issue.mode.freeform")}
+            <SquarePen />
+            {t("issue.startDraft")}
           </Button>
         </div>
       </PageFooter>

--- a/src/sidepanel/tabs/NetworkSubTab.tsx
+++ b/src/sidepanel/tabs/NetworkSubTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { PenLine } from "lucide-react";
+import { SquarePen } from "lucide-react";
 import { useT } from "@/i18n";
 import { Button } from "@/components/ui/button";
 import { useEditorStore } from "@/store/editor-store";
@@ -35,8 +35,8 @@ export function NetworkSubTab({ active, onStartFreeform }: { active: boolean; on
       <PageFooter>
         <div className="flex justify-end">
           <Button variant="outline" onClick={onStartFreeform}>
-            <PenLine />
-            {t("issue.mode.freeform")}
+            <SquarePen />
+            {t("issue.startDraft")}
           </Button>
         </div>
       </PageFooter>


### PR DESCRIPTION
## Summary
- Rename log tab (Console/Network) freeform button label from "자유 작성" to "이슈 작성" with `SquarePen` icon
- Fix inline image GC regex not matching UUID hyphens (data loss risk)
- Unify inline image refId format to 8-char slug
- Fix blob URL leak on cancelled effect in DocSectionBody

## Test plan
- [ ] Verify Console/Network sub-tab button shows "이슈 작성" with SquarePen icon
- [ ] Verify IssueTab mode selector still shows "자유 작성" with PenLine icon
- [x] 775 unit tests passing
- [x] TypeScript type check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)