### PR TITLE
fix(pages): exclude internal feature docs from Jekyll build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-minimal
 title: BugShot
+exclude:
+  - features


### PR DESCRIPTION
## Problem
The `pages-build-deployment` workflow failed on the v1.3.1 merge commit (`032a454`):

```
Liquid Exception: Liquid syntax error (line 157): Unknown tag 'hint' in features/guide-content/design.md
```

GitHub Pages builds all of `docs/` with Jekyll, including the internal `docs/features/` planning docs. `guide-content/design.md:157` (and `tasks.md:11`) contain the literal `{% hint %}` inside an inline-code span — ironically while explaining NOT to use GitBook syntax. Liquid parses `{% ... %}` before markdown code spans are applied, so the backticks don't protect it.

## Fix
Add `exclude: [features]` to `docs/_config.yml`. The `docs/` site only needs to publish `privacy.md`; the feature planning docs were never meant to be public. This fixes the build, hides internal planning docs, and prevents recurrence if any future GitBook syntax lands in `features/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)