### PR TITLE
v1.3.15: Show current value in per-side border-style fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.3.14",
+  "version": "1.3.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sidepanel/tabs/styleEditor/StylePropEditors.tsx
+++ b/src/sidepanel/tabs/styleEditor/StylePropEditors.tsx
@@ -433,9 +433,12 @@ function SideStyleSelect({
     else set(next);
   };
   return (
-    <Select value={value} onValueChange={commit}>
+    <Select value={current} onValueChange={commit}>
       <SelectTrigger
-        className={cn("h-9 gap-1 px-2", isDefault && "opacity-50")}
+        className={cn(
+          "h-9 gap-1 px-1.5 [&>svg:last-child]:hidden",
+          isDefault && "text-muted-foreground/50",
+        )}
         title={`${sideTitle} · ${current || "none"}`}
         aria-label={sideTitle}
       >
@@ -444,6 +447,9 @@ function SideStyleSelect({
           style={current}
           className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
         />
+        <span className="min-w-0 flex-1 truncate text-left text-xs">
+          {current || "none"}
+        </span>
       </SelectTrigger>
       <SelectContent>
         {BORDER_STYLE_OPTIONS.map((o) => (


### PR DESCRIPTION
## Summary

Fixes the per-side **border-style** controls so each side's trigger shows its current value.

## Fixes

- **Per-side border-style now shows the selected value.** The icon-only trigger couldn't convey styles like `double`, `groove`, or `inset`, and computed (unedited) values weren't reflected at all. Each side now renders the effective style (`solid` / `dashed` / `dotted` / …) as text next to the side icon, the chevron is hidden to fit the four-up width, and the dropdown highlight matches the shown value.

## Verification
- `pnpm typecheck` — clean.
- `pnpm test:e2e` — full e2e suite green (90 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)