### PR TITLE
v1.4.2: normalize unspecified position offsets to auto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/content/__tests__/css-resolve.test.ts
+++ b/src/content/__tests__/css-resolve.test.ts
@@ -24,6 +24,7 @@ import {
   collectReferencedTokenNames,
   parseBorderShorthand,
   expandShorthands,
+  normalizePositionOffsets,
   type EditableHandle,
 } from "../css-resolve";
 
@@ -244,6 +245,49 @@ describe("expandShorthands — border shorthand 전개", () => {
     expandShorthands(all, {});
     expect(all["border-top-color"]).toBe("var(--accent)");
     expect(all["border-right-color"]).toBe("red");
+  });
+
+  it("inset 단축 → top/right/bottom/left TRBL 전개", () => {
+    const all: Record<string, string> = { inset: "16px 24px" };
+    const sources: Record<string, string> = { inset: ".box" };
+    expandShorthands(all, sources);
+    expect(all.top).toBe("16px");
+    expect(all.right).toBe("24px");
+    expect(all.bottom).toBe("16px");
+    expect(all.left).toBe("24px");
+    expect(sources.top).toBe(".box");
+  });
+
+  it("inset 단축은 기존 longhand를 안 덮음 (fill-if-absent)", () => {
+    const all: Record<string, string> = { inset: "0px", top: "10px" };
+    expandShorthands(all, {});
+    expect(all.top).toBe("10px");
+    expect(all.bottom).toBe("0px");
+  });
+});
+
+describe("normalizePositionOffsets — 미지정 오프셋 auto 정규화", () => {
+  it("작성자 미지정 변은 computed used px 대신 auto", () => {
+    const computed: Record<string, string> = {
+      top: "16px",
+      right: "480px",
+      bottom: "240px",
+      left: "24px",
+    };
+    const specified: Record<string, string> = { top: "16px", left: "24px" };
+    normalizePositionOffsets(computed, specified);
+    expect(computed.top).toBe("16px");
+    expect(computed.left).toBe("24px");
+    expect(computed.right).toBe("auto");
+    expect(computed.bottom).toBe("auto");
+  });
+
+  it("작성자 지정 변은 computed 값을 보존", () => {
+    const computed: Record<string, string> = { top: "16px", bottom: "8px" };
+    const specified: Record<string, string> = { top: "16px", bottom: "8px" };
+    normalizePositionOffsets(computed, specified);
+    expect(computed.top).toBe("16px");
+    expect(computed.bottom).toBe("8px");
   });
 });
 

--- a/src/content/css-resolve.ts
+++ b/src/content/css-resolve.ts
@@ -138,9 +138,11 @@ const SHORTHAND_MAP: Record<string, string[]> = {
     "border-left-style",
   ],
   overflow: ["overflow-x", "overflow-y"],
+  inset: ["top", "right", "bottom", "left"],
 };
 
 const TRBL_SHORTHANDS: Record<string, [string, string, string, string]> = {
+  inset: ["top", "right", "bottom", "left"],
   padding: [
     "padding-top",
     "padding-right",
@@ -234,6 +236,7 @@ export function collectSelection(
   }
   const { styles: specifiedStyles, sources: propSources } =
     collectSpecifiedStylesWithSources(el);
+  normalizePositionOffsets(computedStyles, specifiedStyles);
   const editableHandle = captureEditable(el);
   return {
     selector,
@@ -939,6 +942,18 @@ function extractVarPropsFromMap(
         sources[lh] = origin;
       }
     }
+  }
+}
+
+// getComputedStyle은 absolute/fixed 요소의 미지정 오프셋을 auto가 아니라 containing block
+// 경계까지의 used px로 resolve한다. 작성자가 지정하지 않은 변(specified에 없음)은 cascaded
+// 값(auto)으로 되돌려 편집 필드·diff가 used px를 실제 설정값처럼 노출하지 않게 한다.
+export function normalizePositionOffsets(
+  computedStyles: Record<string, string>,
+  specifiedStyles: Record<string, string>,
+): void {
+  for (const p of ["top", "right", "bottom", "left"]) {
+    if (!(p in specifiedStyles)) computedStyles[p] = "auto";
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a style-panel bug where the position inset fields (top/right/bottom/left) showed large pixel numbers for sides the author never set.

`getComputedStyle` resolves unset `top`/`right`/`bottom`/`left` on `absolute`/`fixed` elements to the used px distance to the containing block, not `auto`. The editor's placeholder fallback (`specified || computed`) then surfaced those large px as if they were authored values — e.g. setting only `top: 16px; left: 24px` displayed big numbers in `right`/`bottom`.

## Changes

- **`normalizePositionOffsets`** (css-resolve): at capture, a position offset absent from `specifiedStyles` is reported as its cascaded value (`auto`) instead of the computed used px. Fixes the editor fields, the diff table, and change detection consistently (all share `computedStyles`).
- **`inset` shorthand expansion**: added `inset` to the shorthand maps so `inset`-authored values land in `specifiedStyles` and aren't wiped to `auto` by the normalization.
- Unit tests for both the normalization and `inset` TRBL expansion.

## Verification

- `pnpm test` — all unit tests pass
- `pnpm typecheck` — clean
- `pnpm test:e2e` — 143 passed (incl. style-position-section, style-cross-origin-section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)