### PR TITLE
ci: auto-redeploy bugshot-web on privacy source changes

### DIFF
--- a/.github/workflows/trigger-web-deploy.yml
+++ b/.github/workflows/trigger-web-deploy.yml
@@ -1,0 +1,14 @@
+name: Trigger bugshot-web deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/privacy.ko.md"
+      - "docs/privacy.en.md"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL -X POST "${{ secrets.WEB_DEPLOY_HOOK }}"


### PR DESCRIPTION
Add `.github/workflows/trigger-web-deploy.yml`: on push to `main` touching
`docs/privacy.ko.md` or `docs/privacy.en.md`, POST the Vercel deploy hook
(`WEB_DEPLOY_HOOK` secret) so `bug-shot.com/{ko,en}/privacy` rebuilds from the
updated sources (build-time fetch). No version bump (CI-only).

Extend `paths` with `guide/**` when the docs portal lands (shared hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)