### PR TITLE
v1.5.2: default_locale en for store listing fallback

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -10,7 +10,7 @@ export default defineManifest({
   short_name: "__MSG_EXT_NAME_SHORT__",
   description: "__MSG_EXT_DESCRIPTION__",
   version: pkg.version,
-  default_locale: "ko",
+  default_locale: "en",
   minimum_chrome_version: "116",
   ...(isStoreBuild ? {} : { key: DEV_KEY }),
   icons: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- **chore(manifest)**: change `default_locale` from `ko` to `en`. Browsers whose UI language has no matching `_locales` folder (ja/zh/fr/…) and the Chrome Web Store default listing now fall back to English instead of Korean.

Runtime app locale (settings store / `detectLocale`) and the log viewer are unaffected — this only touches `chrome.i18n __MSG__` substitution and store listing metadata.

## Test

- e2e: 169 passed (rebuilt with `default_locale: "en"`)
- No doc updates: `default_locale` is not documented in any repo doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)