### PR TITLE
v1.6.11: Wider side-panel dialogs (90vw)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -224,7 +224,7 @@ shadcn `Slider` (`src/components/ui/slider.tsx`, Radix). 표준에서 **멀티 t
 - 현재 활성 사용처는 없다(이전 유일 예 `LogAttachmentCards`가 단일 카드로 전환되며 `@container`/grid 제거). 플러그인은 설치돼 있어 필요 시 재도입 가능.
 
 ### 오버레이 컴포넌트
-- **Dialog** (`dialog.tsx`): 기본 `DialogContent` = `rounded-2xl`, `w-full max-w-[calc(100%-2rem)]`, `duration-300`. 넓게 띄워야 하면 override(예: `SubmitFieldsDialog`의 `w-[80vw] max-w-[80vw] max-h-[80vh] rounded-3xl`). `DialogFooter`는 `flex-col-reverse sm:flex-row` + `rounded-b-2xl`.
+- **Dialog** (`dialog.tsx`): 기본 `DialogContent` = `rounded-2xl`, `w-full max-w-[calc(100%-2rem)]`, `duration-300`. 넓게 띄워야 하면 override(예: `SubmitFieldsDialog`의 `w-[90vw] max-w-[90vw] max-h-[80vh] rounded-3xl`). `DialogFooter`는 `flex-col-reverse sm:flex-row` + `rounded-b-2xl`.
 - **Popover** (`popover.tsx`): 기본 `align=center sideOffset=4 collisionPadding=8`, `w-72`, 높이는 `--radix-popover-content-available-height`. 콤보박스에 다수 사용.
 - **ScrollArea** (`scroll-area.tsx`): 로그 콘텐츠 패널 공통. 커스텀 스크롤바는 `globals.css`의 `::-webkit-scrollbar`(10px, thumb=border 색, hover 시 muted-foreground/0.5)와 일관.
 - **Resizable** (`resizable.tsx`): 분할 레이아웃(주로 log-viewer 비디오+로그 패널).

--- a/docs/POSTMORTEM.md
+++ b/docs/POSTMORTEM.md
@@ -21,6 +21,13 @@
 
 ---
 
+## 2026-07-22 — body-portal 풀스크린 오버레이를 Radix modal Dialog 안에서 트리거하면 캔버스 클릭이 다이얼로그를 닫는다 (latent — 기능 프로토타입은 롤백)
+
+- **증상**: 저장된 초안 편집 창(`DraftEditDialog`, Radix `Dialog`)의 본문 tiptap에 인라인 이미지를 넣고 `[주석 달기]`를 눌러 어노테이션 오버레이가 떠도, 캔버스에 그리려 클릭하면 **편집 다이얼로그가 통째로 닫혀** 주석이 불가능하다. **작성 화면(`DraftingPanel`, 비-modal 패널)에선 같은 오버레이가 정상 동작**해 "여기서만 안 됨"으로 갈린다. (이 경로는 편집 창에 이미지를 붙여넣기/드래그로만 닿아 눈에 잘 안 띄었고, COVERAGE.md에 "DraftEditDialog 오버레이 z-index·focus-trap"이 수동 잔여로만 적혀 있었다. 편집 창에 이미지 추가/로그 삽입 툴바를 얹으려던 시도에서 실사용 경로로 드러났으나 그 기능 자체는 롤백했다 — 함정만 남긴다.)
+- **근본 원인**: 표면(주석이 안 됨)과 원인(오버레이가 다이얼로그를 닫음)이 다른 레이어. `AnnotationOverlay`는 `createPortal(document.body)` + `fixed inset-0 z-50` **풀스크린**이라 DOM상 **Radix `Dialog`의 서브트리 바깥**에 렌더된다. Radix modal Dialog는 `DismissableLayer`로 콘텐츠 **바깥의 pointerdown을 "interact outside"로 잡아 `onOpenChange(false)`**(닫기)를 부른다 → 오버레이 캔버스(=다이얼로그 바깥 DOM) 클릭이 곧 다이얼로그 닫힘 트리거. **z-index를 올려도 안 된다** — 스택 순서가 아니라 pointer/focus 소유권 문제다. DraftingPanel은 비-modal이라 DismissableLayer가 없어 무사하다.
+- **재발 방지**: (1) **`createPortal(document.body)` 풀스크린 인터랙티브 오버레이를 Radix modal `Dialog`/`AlertDialog` 안에서 트리거하지 말 것**. `grep -rn 'createPortal' src/sidepanel/components`로 body-portal 오버레이를 찾고, 그 트리거가 `Dialog`/`AlertDialog`(`src/components/ui/dialog.tsx`·`alert-dialog.tsx`) 안에서 발화하는지 본다. 해법 셋 — ⓐ 그 컨텍스트에서 기능을 끈다(예: 편집 창에선 인라인 이미지 주석을 비활성) ⓑ 오버레이를 다이얼로그 콘텐츠 **안**에 렌더(풀스크린이면 부적합) ⓒ 다이얼로그의 `onInteractOutside`/`onPointerDownOutside`를 오버레이 오픈 동안 `preventDefault`(오버레이 상태를 다이얼로그로 끌어올려야 함). (2) **"A에선 되는데 B에선 안 됨"은 컴포넌트가 아니라 호스트의 래핑(modal vs 비-modal) 차이를 먼저 의심**한다 — pointer/focus 정책이 다르다. (3) **이 부류는 jsdom·순수 테스트로 안 잡힌다** — Radix DismissableLayer 실동작이라 e2e/수동이 유일한 그물. (4) **COVERAGE의 "수동 잔여"에 이미 적힌 위험은 그 경로를 실사용에 노출하기 전에 되짚는다** — 예견됐으나 방치된 항목이 신기능 배선으로 활성화되는 계열.
+- **관련**: `src/sidepanel/components/AnnotationOverlay.tsx`(`fixed inset-0 z-50` + `createPortal(document.body)`), 호스트 `src/components/ui/dialog.tsx`(Radix `DismissableLayer`), 트리거 `src/sidepanel/components/TiptapEditor.tsx`(인라인 이미지 어노테이션 NodeView → 오버레이 오픈), 노출 컨텍스트 `src/sidepanel/tabs/DraftEditDialog.tsx`(Radix Dialog가 tiptap 편집기를 호스트). 계열: **2026-07-01**(두 lazy 청크 동시 마운트 — 같은 "오버레이×다이얼로그" 조합의 다른 함정).
+
 ## 2026-07-21 — AI 오버레이 '중단'(소프트취소)을 3개 AI 콜사이트에 얹을 때, 취소 가드가 한 곳만 있었고 사용자 취소가 re-adopt로 되살아났다
 
 - **증상**: (구현 중 `/code-review`가 잡음 — 미출시) AI 로딩 오버레이에 공용 '중단' 버튼을 달았는데, ① repro에서 사용자가 중단을 눌러도 게이트 왕복(trimming 등 dep 변경)으로 effect가 재발화하면 취소한 요청이 **되살아나 늦게 온 재현 단계가 적용**됐다. ② draft·styling 다이얼로그에서 중단을 누르면 배경 호출이 실패로 끝날 때(특히 `isPromptOverBudget` await 창에서 취소 → canceller가 `sessionRef=null` → 다음 줄 `sessionRef.current.prompt()`가 **null-deref TypeError**) 사용자가 방금 취소한 작업에 **AI 에러 토스트**가 떴다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bugshot-2",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bugshot-2",
-      "version": "1.6.10",
+      "version": "1.6.11",
       "dependencies": {
         "@medv/finder": "^4.0.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bugshot-2",
   "private": true,
-  "version": "1.6.10",
+  "version": "1.6.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sidepanel/components/LogInsertDialog.tsx
+++ b/src/sidepanel/components/LogInsertDialog.tsx
@@ -72,7 +72,7 @@ export function LogInsertDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="log-insert-dialog"
-        className="w-[80vw] max-w-[80vw] h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
+        className="w-[90vw] max-w-[90vw] h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
       >
         <DialogHeader>
           <DialogTitle className="text-xl">{t("logInsert.dialog.title")}</DialogTitle>

--- a/src/sidepanel/components/LogPreviewDialog.tsx
+++ b/src/sidepanel/components/LogPreviewDialog.tsx
@@ -61,7 +61,7 @@ export function LogPreviewDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="log-preview-dialog"
-        className="w-[80vw] max-w-[80vw] h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
+        className="w-[90vw] max-w-[90vw] h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
       >
         <DialogHeader>
           <DialogTitle className="text-xl">logs.html</DialogTitle>

--- a/src/sidepanel/tabs/AiDraftDialog.tsx
+++ b/src/sidepanel/tabs/AiDraftDialog.tsx
@@ -256,7 +256,7 @@ export function AiDraftDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("aiDraft.title")}</DialogTitle>
         </DialogHeader>

--- a/src/sidepanel/tabs/DomTreeDialog.tsx
+++ b/src/sidepanel/tabs/DomTreeDialog.tsx
@@ -76,7 +76,7 @@ export function DomTreeTitle({ tagName, classList }: { tagName: string; classLis
           {label}
         </button>
       </DialogTrigger>
-      <DialogContent className="w-[80vw] max-w-[80vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("dom.dialogTitle")}</DialogTitle>
         </DialogHeader>

--- a/src/sidepanel/tabs/DraftDetailDialog.tsx
+++ b/src/sidepanel/tabs/DraftDetailDialog.tsx
@@ -863,7 +863,7 @@ export function DraftDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-[80vw] max-w-[80vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl" data-testid="draft-detail-dialog">
+        <DialogContent className="w-[90vw] max-w-[90vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl" data-testid="draft-detail-dialog">
               <DialogHeader>
                 <DialogTitle className="text-xl">{t("draftDetail.title")}</DialogTitle>
               </DialogHeader>

--- a/src/sidepanel/tabs/DraftEditDialog.tsx
+++ b/src/sidepanel/tabs/DraftEditDialog.tsx
@@ -63,7 +63,7 @@ export function DraftEditDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex w-[80vw] max-w-[80vw] max-h-[80vh] flex-col gap-5 rounded-3xl p-6 sm:rounded-3xl"
+        className="flex w-[90vw] max-w-[90vw] max-h-[80vh] flex-col gap-5 rounded-3xl p-6 sm:rounded-3xl"
         data-testid="draft-edit-dialog"
       >
         <DialogHeader>

--- a/src/sidepanel/tabs/SubmitFieldsDialog.tsx
+++ b/src/sidepanel/tabs/SubmitFieldsDialog.tsx
@@ -256,7 +256,7 @@ export function SubmitFieldsDialog(props: SubmitFieldsDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[80vh] w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl" data-testid="submit-fields-dialog">
+      <DialogContent className="max-h-[80vh] w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl" data-testid="submit-fields-dialog">
         <DialogHeader>
           <DialogTitle className="text-xl">{title ?? t("issue.submit")}</DialogTitle>
         </DialogHeader>

--- a/src/sidepanel/tabs/connect/AsanaConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/AsanaConnectForm.tsx
@@ -269,7 +269,7 @@ function PatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("asana.patDialog.title")}</DialogTitle>
           <DialogDescription>{t("asana.patDialog.body")}</DialogDescription>

--- a/src/sidepanel/tabs/connect/ClickupConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/ClickupConnectForm.tsx
@@ -297,7 +297,7 @@ function PatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("clickup.patDialog.title")}</DialogTitle>
           <DialogDescription>{t("clickup.patDialog.body")}</DialogDescription>

--- a/src/sidepanel/tabs/connect/ConnectMethodDialog.tsx
+++ b/src/sidepanel/tabs/connect/ConnectMethodDialog.tsx
@@ -33,7 +33,7 @@ export function ConnectMethodDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">
             {t("platform.connectMethod.title", { platform: platformLabel })}

--- a/src/sidepanel/tabs/connect/GithubConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/GithubConnectForm.tsx
@@ -242,7 +242,7 @@ function PatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("github.patDialog.title")}</DialogTitle>
           <DialogDescription>

--- a/src/sidepanel/tabs/connect/GitlabConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/GitlabConnectForm.tsx
@@ -282,7 +282,7 @@ function PatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("gitlab.patDialog.title")}</DialogTitle>
           <DialogDescription>

--- a/src/sidepanel/tabs/connect/JiraConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/JiraConnectForm.tsx
@@ -245,7 +245,7 @@ function JiraSiteDialog({
   const t = useT();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("jira.selectSite")}</DialogTitle>
         </DialogHeader>
@@ -324,7 +324,7 @@ function ApiKeyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("jira.apiKeyDialog.title")}</DialogTitle>
           <DialogDescription>
@@ -438,7 +438,7 @@ function SetupDialog() {
       }}
     >
       <DialogContent
-        className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl"
+        className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl"
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >

--- a/src/sidepanel/tabs/connect/LinearConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/LinearConnectForm.tsx
@@ -268,7 +268,7 @@ function ApiKeyDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("linear.apiKeyDialog.title")}</DialogTitle>
           <DialogDescription>

--- a/src/sidepanel/tabs/connect/NotionConnectForm.tsx
+++ b/src/sidepanel/tabs/connect/NotionConnectForm.tsx
@@ -301,7 +301,7 @@ function InternalTokenDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">
             {t("notion.internalToken.dialog.title")}

--- a/src/sidepanel/tabs/settings/LlmConnectDialog.tsx
+++ b/src/sidepanel/tabs/settings/LlmConnectDialog.tsx
@@ -205,7 +205,7 @@ export function LlmConnectDialog({
       onClose={() => setPendingModels(null)}
     />
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("llm.dialog.title")}</DialogTitle>
           <DialogDescription>{t("llm.dialog.body")}</DialogDescription>
@@ -228,7 +228,7 @@ export function LlmConnectDialog({
                   <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-[calc(80vw-48px)] p-0" align="start">
+              <PopoverContent className="w-[calc(90vw-48px)] p-0" align="start">
                 <Command>
                   <CommandInput
                     placeholder={t("llm.baseUrlPlaceholder")}
@@ -343,7 +343,7 @@ function LlmModelDialog({
 
   return (
     <Dialog open={!!pending} onOpenChange={(v) => { if (!v) onClose(); }}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("llm.model.select")}</DialogTitle>
         </DialogHeader>

--- a/src/sidepanel/tabs/styleEditor/AiStylingDialog.tsx
+++ b/src/sidepanel/tabs/styleEditor/AiStylingDialog.tsx
@@ -222,7 +222,7 @@ export function AiStylingDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[80vw] max-w-[80vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
+      <DialogContent className="w-[90vw] max-w-[90vw] gap-5 rounded-3xl p-6 sm:rounded-3xl">
         <DialogHeader>
           <DialogTitle className="text-xl">{t("aiStyling.title")}</DialogTitle>
         </DialogHeader>

--- a/src/sidepanel/tabs/styleEditor/StyleChangesDialog.tsx
+++ b/src/sidepanel/tabs/styleEditor/StyleChangesDialog.tsx
@@ -144,7 +144,7 @@ export function StyleChangesDialog() {
         </Button>
       </DialogTrigger>
       <DialogContent
-        className="w-[80vw] max-w-[80vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
+        className="w-[90vw] max-w-[90vw] max-h-[80vh] gap-5 rounded-3xl p-6 sm:rounded-3xl"
         data-testid="changes-dialog"
       >
         <DialogHeader>


### PR DESCRIPTION
## Summary

Widens every overridden side-panel dialog from **80vw to 90vw**, giving content-heavy dialogs (style changes, log insert, submit fields, DOM tree, connect forms) more usable width in the narrow side panel. Heights are unchanged.

### Changes
- `style(dialogs)` — bump `w-[80vw] max-w-[80vw]` → `90vw` across all 21 side-panel `DialogContent` overrides, plus the dependent LlmConnect popover (`calc(80vw-48px)` → `calc(90vw-48px)`). `max-h/h-[80vh]` heights untouched.
- `docs(DESIGN)` — update the dialog width override example to 90vw.
- `docs(postmortem)` — record a latent pitfall: a body-portal full-screen overlay (e.g. the annotation overlay) triggered inside a Radix modal Dialog has its canvas clicks caught by the DismissableLayer and closes the dialog (works in the non-modal DraftingPanel; z-index does not fix it).

Pure className change — no logic or testid changes. Full e2e suite green (226 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)