### PR TITLE
ci: move off the deprecated Node 20 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # pnpm 버전은 package.json의 packageManager 필드에서 가져온다(단일 출처).
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
The runner warned that `actions/checkout@v4`, `actions/setup-node@v4` and
`pnpm/action-setup@v4` all target Node 20 and were being forced onto Node
24. These majors are runtime bumps; the inputs this workflow uses
(`node-version`, `cache`, and action-setup reading `packageManager`) are
unchanged, so it is a three-line move.

Verified on dev: the CI run is green through every step and the
deprecation annotation is gone. Local e2e 238 passing.

No version bump - workflow config only, nothing in the extension bundle.